### PR TITLE
Correct typo in replication endpoint

### DIFF
--- a/docs/http-api/replication-api.mdx
+++ b/docs/http-api/replication-api.mdx
@@ -131,7 +131,7 @@ The replication is performed in the background and doesn't affect the performanc
 
 <SwaggerComponent
   method="POST"
-  path="/api/v1/replication/:replication"
+  path="/api/v1/replications/:replication"
   summary="Create a new replication"
   description={
     <>


### PR DESCRIPTION
The path to create a replication was missing an "s"
