### PR TITLE
RS-257: White paper slide in banner on blog pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,11 @@
     "react-tooltip": "^5.26.0",
     "reduct-js": "^1.9.2",
     "search-insights": "^2.10.0",
-    "vanilla-cookieconsent": "3.0.0",
+    "vanilla-cookieconsent": "3.0.1",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
-    "xterm-addon-web-links": "^0.9.0"
+    "xterm-addon-web-links": "^0.9.0",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.0.1",

--- a/src/components/SlidingBanner/index.tsx
+++ b/src/components/SlidingBanner/index.tsx
@@ -25,7 +25,7 @@ const SlidingBanner: React.FC = () => {
       const timeout = setTimeout(() => {
         setVisible(true);
         setBannerShown(true);
-      }, 1500);
+      }, 13_000);
       return () => clearTimeout(timeout);
     }
   }, [isModalOpen, wasBannerShown, setBannerShown, setVisible, isCorrectPath]);

--- a/src/components/SlidingBanner/index.tsx
+++ b/src/components/SlidingBanner/index.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import Link from "@docusaurus/Link";
+import Cookies from 'js-cookie';
+import styles from './styles.module.css';
+
+const whitePaperImage = require("@site/static/img/whitepaper/whitepaper.webp").default;
+
+const SlidingBanner: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (Cookies.get('cc_reductstore') != null &&
+      Cookies.get('reductstore_bannerDismissed') !== 'true') {
+      const timeout = setTimeout(() => {
+        if (window.innerWidth > 768) {
+          setVisible(true);
+        }
+      }, 10_000);
+      return () => clearTimeout(timeout);
+    }
+  }, []);
+
+  const handleClose = () => {
+    setVisible(false);
+    Cookies.set('reductstore_bannerDismissed', 'true', { expires: 7 });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className={styles.banner}>
+      <div className={styles.bannerContent}>
+        <img src={whitePaperImage} alt="White Paper" className={styles.image} />
+        <div className={styles.textBlock}>
+          <div className={styles.title}>Free White Paper</div>
+          <div className={styles.subtitle}>Get Your White Paper: AI on the Edge!</div>
+          <Link to="/whitepaper" className="button button--primary button--lg">
+            Download Now →
+          </Link>
+        </div>
+      </div>
+      <button className={styles.closeButton} onClick={handleClose}>×</button>
+    </div>
+  );
+};
+
+export default SlidingBanner;

--- a/src/components/SlidingBanner/index.tsx
+++ b/src/components/SlidingBanner/index.tsx
@@ -2,27 +2,43 @@ import React, { useEffect, useState } from "react";
 import Link from "@docusaurus/Link";
 import Cookies from 'js-cookie';
 import styles from './styles.module.css';
-
+import useCookieConsentStore from "@site/src/store/useCookieConsentStore";
+import { useLocation } from '@docusaurus/router';
 const whitePaperImage = require("@site/static/img/whitepaper/whitepaper.webp").default;
 
 const SlidingBanner: React.FC = () => {
   const [visible, setVisible] = useState(false);
+  const { isModalOpen, wasBannerShown, setBannerShown } = useCookieConsentStore();
+  const pagePath = useLocation().pathname;
+  const isCorrectPath = !pagePath.endsWith('/blog');
 
   useEffect(() => {
-    if (Cookies.get('cc_reductstore') != null &&
-      Cookies.get('reductstore_bannerDismissed') !== 'true') {
+    const isMobile = window.innerWidth <= 768;
+    const isDismissed = Cookies.get('reductstore_bannerDismissed') === 'true';
+    if (
+      isCorrectPath &&
+      !isModalOpen &&
+      !wasBannerShown &&
+      !isMobile &&
+      !isDismissed
+    ) {
       const timeout = setTimeout(() => {
-        if (window.innerWidth > 768) {
-          setVisible(true);
-        }
-      }, 10_000);
+        setVisible(true);
+        setBannerShown(true);
+      }, 1500);
       return () => clearTimeout(timeout);
     }
-  }, []);
+  }, [isModalOpen, wasBannerShown, setBannerShown, setVisible, isCorrectPath]);
 
   const handleClose = () => {
     setVisible(false);
     Cookies.set('reductstore_bannerDismissed', 'true', { expires: 7 });
+  };
+
+  const handleDownloadClick = () => {
+    if (window._paq) {
+      window._paq.push(['trackEvent', 'Slide-In Banner', 'White Paper Click', pagePath]);
+    }
   };
 
   if (!visible) return null;
@@ -34,7 +50,7 @@ const SlidingBanner: React.FC = () => {
         <div className={styles.textBlock}>
           <div className={styles.title}>Free White Paper</div>
           <div className={styles.subtitle}>Get Your White Paper: AI on the Edge!</div>
-          <Link to="/whitepaper" className="button button--primary button--lg">
+          <Link to="/whitepaper" className="button button--primary button--lg" onClick={handleDownloadClick}>
             Download Now →
           </Link>
         </div>

--- a/src/components/SlidingBanner/styles.module.css
+++ b/src/components/SlidingBanner/styles.module.css
@@ -1,0 +1,66 @@
+.banner {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background-color: white;
+  color: #000;
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  border: 0.1rem solid var(--ifm-color-primary-lighter);
+  border-radius: 5px;
+  animation: slide-in 0.5s forwards, overshoot 0.5s 0.5s forwards;
+  z-index: 1000;
+}
+
+@keyframes slide-in {
+  from { right: -100%; }
+  to { right: 80px; }
+}
+
+@keyframes overshoot {
+  0% { right: 80px; }
+  100% { right: 20px; }
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: #666;
+  font-size: 24px;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding-right: 10px;
+  padding-top: 5px;
+}
+
+.bannerContent {
+  display: flex;
+  align-items: center;
+}
+
+.image {
+  height: 107px;
+  margin-right: 15px;
+  border: 1px solid var(--ifm-color-primary-lighter);
+  border-radius: 5px;
+}
+
+.textBlock {
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  font-size: 12px;
+  color: #666;
+}
+
+.subtitle {
+  font-size: 16px;
+  margin-bottom: 10px;
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Window {
+    _paq: any[];
+  }
+}

--- a/src/pages/whitepaper/index.tsx
+++ b/src/pages/whitepaper/index.tsx
@@ -4,7 +4,7 @@ import Layout from "@theme/Layout";
 import WhitePaperForm from "@site/src/components/WhitePaperForm";
 import styles from './styles.module.css';
 
-const LogoImg = require("@site/static/img/whitepaper/whitepaper.webp").default;
+const WhitePaperImg = require("@site/static/img/whitepaper/whitepaper.webp").default;
 
 export default function ReductAI(): JSX.Element {
   return (
@@ -21,7 +21,7 @@ export default function ReductAI(): JSX.Element {
             </div>
             <div className="col col--4 col--offset-1 hideOnMobile">
               <img
-                src={LogoImg}
+                src={WhitePaperImg}
                 alt="White Paper Cover"
                 className={styles.whitePaperImage}
               />

--- a/src/store/useCookieConsentStore.ts
+++ b/src/store/useCookieConsentStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+interface CookieConsentState {
+  isModalOpen: boolean;
+  setModalOpen: (isOpen: boolean) => void;
+  wasBannerShown: boolean;
+  setBannerShown: (shown: boolean) => void;
+}
+
+const useCookieConsentStore = create<CookieConsentState>((set) => ({
+  isModalOpen: false,
+  setModalOpen: (isOpen) => set({ isModalOpen: isOpen }),
+  wasBannerShown: false,
+  setBannerShown: (shown) => set({ wasBannerShown: shown }),
+}));
+
+export default useCookieConsentStore;

--- a/src/theme/BlogPostItem/index.js
+++ b/src/theme/BlogPostItem/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import BlogPostItem from "@theme-original/BlogPostItem";
 import SocialShareBar from "@site/src/components/SocialShareBar";
+import SlidingBanner from "@site/src/components/SlidingBanner";
 
 export default function BlogPostItemWrapper(props) {
   const { frontMatter } = props.children.type;
@@ -8,6 +9,7 @@ export default function BlogPostItemWrapper(props) {
     <>
       <SocialShareBar frontMatter={frontMatter} />
       <BlogPostItem {...props} />
+      <SlidingBanner />
     </>
   );
 }

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,13 +1,22 @@
-import React from "react";
+import React, { useState } from "react";
 import { useEffect } from "react";
-
 import { initializeCookieConsent } from "./cookieConsent";
+import { useLocation } from "@docusaurus/router";
+import useCookieConsentStore from "@site/src/store/useCookieConsentStore";
 
 export default function Root({ children }) {
+  const location = useLocation();
+  const [initialized, setInitialized] = useState(false);
+  const { setModalOpen } = useCookieConsentStore.getState();
   useEffect(() => {
+    if (initialized) {
+      setModalOpen(false);
+      return;
+    }
     setTimeout(() => {
       initializeCookieConsent();
+      setInitialized(true);
     }, 1000);
-  }, []);
+  }, [location.pathname]);
   return <>{children}</>;
 }

--- a/src/theme/cookieConsent.js
+++ b/src/theme/cookieConsent.js
@@ -10,7 +10,7 @@ const cookieConsentConfig = {
   guiOptions: {
     consentModal: {
       layout: "box",
-      position: "bottom right",
+      position: "bottom left",
       equalWeightButtons: true,
       flipButtons: false,
     },

--- a/src/theme/cookieConsent.js
+++ b/src/theme/cookieConsent.js
@@ -1,5 +1,6 @@
 import "vanilla-cookieconsent/dist/cookieconsent.css";
 import * as CookieConsent from "vanilla-cookieconsent";
+import useCookieConsentStore from "@site/src/store/useCookieConsentStore";
 
 const cookieConsentConfig = {
   cookie: {
@@ -7,10 +8,16 @@ const cookieConsentConfig = {
   },
   onFirstConsent: handleConsent,
   onChange: handleConsent,
+  onModalShow: () => {
+    useCookieConsentStore.getState().setModalOpen(true);
+  },
+  onModalHide: () => {
+    useCookieConsentStore.getState().setModalOpen(false);
+  },
   guiOptions: {
     consentModal: {
       layout: "box",
-      position: "bottom left",
+      position: "bottom right",
       equalWeightButtons: true,
       flipButtons: false,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8249,6 +8249,11 @@ url-loader@^4.1.1:
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -8279,10 +8284,10 @@ value-equal@^1.0.1:
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
-vanilla-cookieconsent@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/vanilla-cookieconsent/-/vanilla-cookieconsent-3.0.0.tgz#2f5ff996a5cc256c6296f89746da7e0ce2bf6af5"
-  integrity sha512-oeK7FivRDb424mt3/UT8DG98Pu5m6Uuye7JsdzO6HnYkstW5QHXhkslXyUpE3phtKz3NEeIo7hzLUtfRNRMfbQ==
+vanilla-cookieconsent@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/vanilla-cookieconsent/-/vanilla-cookieconsent-3.0.1.tgz#059d1b2c712476ae4172d4ec7fa9d553a16be12d"
+  integrity sha512-gqc4x7O9t1I4xWr7x6/jtQWPr4PZK26SmeA0iyTv1WyoECfAGnu5JEOExmMEP+5Fz66AT9OiCBO3GII4wDQHLw==
 
 vary@~1.1.2:
   version "1.1.2"
@@ -8578,6 +8583,13 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+zustand@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.5.2.tgz#fddbe7cac1e71d45413b3682cdb47b48034c3848"
+  integrity sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==
+  dependencies:
+    use-sync-external-store "1.2.0"
 
 zwitch@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
This PR introduces a slide-in banner to offer the white paper when visiting blog pages.

At the same time, the following was implemented:
- track event on Matomo
- only show up on very specific conditions:
  - cookie banner is hidden
  - max one time per session (don't appear again when navigating other blog pages)
  - don't appear for 7 days if closed by the user (based on cookie)
  - don't appear on mobile

<img width="1434" alt="Screenshot 2024-04-24 at 14 46 16" src="https://github.com/reductstore/website/assets/26444489/06bdb3c3-a369-4c94-9cce-21b4af1095da">