### PR TITLE
RS-261: Describe `each_n` and `each_s` parameters

### DIFF
--- a/docs/guides/data-querying.mdx
+++ b/docs/guides/data-querying.mdx
@@ -26,44 +26,67 @@ While it is possible to retrieve a record by its timestamp, this method is less 
 
 ## Query Parameters
 
-Data can be queried using the ReductStore CLI, SDKs or HTTP API. The query parameters are the same for all interfaces and include:
+Data can be queried using the ReductStore CLI, SDKs or HTTP API. The query parameters are the same for all interfaces and
+divided into two categories: filter and control parameters.
 
-- Start and end time range
-- List of label values to include
-- List of labels to exclude
-- Limit on the number of records to return
-- Head flag to retrieve metadata only
+### Filter Parameters
 
-There are also more advanced parameters available in the SDKs and HTTP API, such as
+Filter parameters are used to select records based on specific criteria. You can combine multiple filter parameters to create complex queries. This is the list of filter parameters, sorted by priority:
+| Parameter | Description                     | Type            | Default                                        |
+|-----------|---------------------------------|-----------------|------------------------------------------------|
+| `start`   | Start time of the query         | Timestamp       | The timestamp of the first record in the entry |
+| `end`     | End time of the query           | Timestamp       | The timestamp of the last record in the entry  |
+| `include` | List of label values to include | List of strings | Disabled                                       |
+| `exclude` | List of labels to exclude       | List of strings | Disabled                                       |
+| `each_s`  | Return a record every S seconds | Float           | Disabled                                       |
+| `each_n`  | Return only every N record      | Integer         | Disabled                                       |
+| `limit`   | Limit on the number of records  | Integer         | All records are returned                       |
 
-- Query TTL (Time to Live)
-- Continuous flag to keep the query open for continuous data retrieval
-- Pool interval to specify the time interval for pooling data in continuous mode
-
-### Time Range
+**Time Range**
 
 The time range is defined by the `start` and `end` parameters. Records with a timestamp equal to or greater than `start` and less than `end` are included in the result. If the `start` parameter is not set, the query starts from the begging of the entry. If the `end` parameter is not set, the query continues to the end of the entry. If both `start` and `end` are not set, the query returns the entire entry.
 
-### Include Labels
+**Include Labels**
 
 The `include` parameter filters the records by the specified label values. Only those that match ALL the specified label values are included in the result.
 
-### Exclude Labels
+**Exclude Labels**
 
 The `exclude` parameter filters records based on specified labels. Any records matching ALL of these labels will be omitted from the results.
 
-### Limit Records
+**One Record Every S Seconds**
+
+The `each_s` parameter returns a record every S seconds. This parameter is useful when you need to resample data at a specific interval. You can use floating-point numbers for better precision. The default value is 0, which means all records are returned.
+
+**Every Nth Record**
+
+The `each_n` parameter returns only every Nth record. This parameter is useful when you need to downsample data by skipping records. The default value is 1, which means all records are returned.
+
+**Limit Records**
 
 The `limit` parameter restricts the number of records returned by a query. If the dataset has fewer records than the specified limit, all records are returned.
 
-### TTL (Time-to-Live)
+### Control Parameters
+
+There are also more advanced parameters available in the SDKs and HTTP API to control the query behavior:
+
+| Parameter       | Description                                                            | Type    | Default |
+|-----------------|------------------------------------------------------------------------|---------|---------|
+| `ttl`           | Time-to-live of the query. The query is automatically closed after TTL | Integer | 60      |
+| `head`          | Retrieve only metadata                                                 | Boolean | False   |
+| `continuous`    | Keep the query open for continuous data retrieval                      | Boolean | False   |
+| `pool_interval` | Time interval for pooling data in continuous mode                      | Integer | 1       |
+
+
+**TTL (Time-to-Live)**
 
 The `ttl` parameter determines the time-to-live of a query. The query is automatically closed when the specified time has elapsed since it was created. This prevents memory leaks by limiting the number of open queries. The default TTL is 60 seconds.
-### Head Flag
+
+**Head Flag**
 
 The `head` flag is used to retrieve only metadata. When set to `true`, the query returns the records' metadata, excluding the actual data. This parameter is useful when you want to work with labels without downloading the content of the records.
 
-### Continuous Mode
+**Continuous Mode**
 
 The `continuous` flag is used to keep the query open for continuous data retrieval. This mode is useful when you need to monitor data in real-time. The SDKs provide `pool_interval` parameter to specify the time interval for pooling data in continuous mode. The default interval is 1 second.
 

--- a/docs/guides/data-querying.mdx
+++ b/docs/guides/data-querying.mdx
@@ -27,7 +27,7 @@ While it is possible to retrieve a record by its timestamp, this method is less 
 ## Query Parameters
 
 Data can be queried using the ReductStore CLI, SDKs or HTTP API. The query parameters are the same for all interfaces and
-divided into two categories: filter and control parameters.
+are divided into two categories: filter and control parameters.
 
 ### Filter Parameters
 

--- a/docs/http-api/entry-api.mdx
+++ b/docs/http-api/entry-api.mdx
@@ -404,6 +404,8 @@ description={
     Since version 1.4, the method has the <code>continuous query</code> flag. If it is true, the current query will not be discarded if there are no records. A client can ask them later. The query will not be removed until its TTL has expired. The <code>stop</code> parameter is ignored for continuous queries.
     <br /><br />
     Since version 1.6, the method provides the <code>limit</code> query parameter. It limits the number of records in the query. If it is not set, the query is unlimited by default.
+    <br /><br />
+    Since version 1.10, the method has the `each_n` and `each_s` query parameters. If the `each_n` parameter is set, the method returns only every `each_n`-th record. If the `each_s` parameter is set, the method returns only one record per `each_s` seconds.
   </>
 }
   parameters={[
@@ -478,12 +480,31 @@ description={
     {
       type: "query",
       details: {
-        name: "limit",
-        description: "Maximum number of records in the query. Default: unlimited.",
-        dataType: "Integer",
-        isRequired: false,
+          name: "limit",
+          description: "Maximum number of records in the query. Default: unlimited.",
+          dataType: "Integer",
+          isRequired: false,
+      }
+    },
+    {
+      type: "query",
+      details: {
+          name: "each_n",
+          description: "Return only every N-th record",
+          dataType: "Integer",
+          isRequired: false,
+      }
+    },
+      {
+      type: "query",
+      details: {
+          name: "each_s",
+          description: "Return only one record per N seconds",
+          dataType: "Float",
+          isRequired: false,
       }
     }
+
   ]}
   responses={[
     {

--- a/docs/http-api/entry-api.mdx
+++ b/docs/http-api/entry-api.mdx
@@ -384,28 +384,38 @@ The Entry API allows users to write and read data from their buckets, as well as
 description={
   <>
     The method responds with a JSON document containing an ID which should be used to read records with the following endpoint:
-    <br />
-    <strong>GET /b/:bucket_name/:entry_name?q=ID.</strong>
-    <br /><br />
+      <p>
+        <strong>GET /b/:bucket_name/:entry_name?q=ID.</strong>
+      </p>
     The time interval is [start, stop).
-    <br /><br />
+    <br />
     If authentication is enabled, the method needs a valid API token with read access to the bucket of the entry.
     <br /><br />
-    Since version 1.3, the method also provides the <code>include-&lt;label&gt;</code> and <code>exclude-&lt;label&gt;</code> query parameters to filter records based on the values of certain labels. For example:
-    <br />
-    <strong>GET /api/v1/:bucket/:entry/q?include-&lt;label1&gt;=foo&amp;exclude-&lt;label2&gt;=bar</strong>
+    <strong> Changes: </strong>
+    <ul>
+        <li>
+            Version 1.3: the method also provides the <code>include-&lt;label&gt;</code> and <code>exclude-&lt;label&gt;</code> query parameters to filter records based on the values of certain labels. For example:
+            <p>
+                <strong>GET /api/v1/:bucket/:entry/q?include-&lt;label1&gt;=foo&amp;exclude-&lt;label2&gt;=bar</strong>
+            </p>
+            This would find all records that have <code>label1</code> equal to "foo" and excludes those that have <code>label2</code> equal to "bar".
+            <br />
+            A user can specify multiple <code>include</code> and <code>exclude</code> labels, which will be connected with an AND operator. For example:
+            <p>
+                <strong>GET /api/v1/:bucket/:entry/q?include-&lt;label1&gt;=foo&amp;include-&lt;label2&gt;=bar</strong>
+            </p>
+        </li>
+    <li>
+            Version 1.4: the method has the <code>continuous query</code> flag. If it is true, the current query will not be discarded if there are no records. A client can ask them later. The query will not be removed until its TTL has expired. The <code>stop</code> parameter is ignored for continuous queries.
+    </li>
+    <li>
+            Version 1.6: the method provides the <code>limit</code> query parameter. It limits the number of records in the query. If it is not set, the query is unlimited by default.
+    </li>
+    <li>
+            Version 1.10: the method has the <code>each_n</code> and <code>each_s</code> query parameters. If the <code>each_n</code> parameter is set, the method returns only every <code>each_n</code>-th record. If the <code>each_s</code> parameter is set, the method returns only one record per <code>each_s</code> seconds.
+    </li>
+    </ul>
     <br /><br />
-    This would find all records that have <code>label1</code> equal to "foo" and excludes those that have <code>label2</code> equal to "bar".
-    <br /><br />
-    A user can specify multiple <code>include</code> and <code>exclude</code> labels, which will be connected with an AND operator. For example:
-    <br />
-    <strong>GET /api/v1/:bucket/:entry/q?include-&lt;label1&gt;=foo&amp;include-&lt;label2&gt;=bar</strong>
-    <br /><br />
-    Since version 1.4, the method has the <code>continuous query</code> flag. If it is true, the current query will not be discarded if there are no records. A client can ask them later. The query will not be removed until its TTL has expired. The <code>stop</code> parameter is ignored for continuous queries.
-    <br /><br />
-    Since version 1.6, the method provides the <code>limit</code> query parameter. It limits the number of records in the query. If it is not set, the query is unlimited by default.
-    <br /><br />
-    Since version 1.10, the method has the `each_n` and `each_s` query parameters. If the `each_n` parameter is set, the method returns only every `each_n`-th record. If the `each_s` parameter is set, the method returns only one record per `each_s` seconds.
   </>
 }
   parameters={[
@@ -472,7 +482,7 @@ description={
       type: "query",
       details: {
         name: "conitnuous",
-        description: "Keep query if no records for the request", 
+        description: "Keep query if no records for the request",
         dataType: "Boolean",
         isRequired: false,
       }
@@ -499,7 +509,7 @@ description={
       type: "query",
       details: {
           name: "each_s",
-          description: "Return only one record per N seconds",
+          description: "Return only one record per S seconds",
           dataType: "Float",
           isRequired: false,
       }

--- a/src/pages/terms.mdx
+++ b/src/pages/terms.mdx
@@ -58,7 +58,7 @@ The following terms have the following meanings:
 
 **Customer**, **you** and **your** means the organization that agrees to an Order Form.
 
-**Documentation** means the instructions, specifications and information regarding the Services or the Software available at **[https://docs.reduct.store](https://docs.reduct.store/)**
+**Documentation** means the instructions, specifications and information regarding the Services or the Software available at **[https://www.reduct.store/docs](https://docs.reduct.store/)**
 
 **ReductStore**, **we**, **our** and **us** means the ReductStore LLC
 


### PR DESCRIPTION
* Re-write the "Query Parameters" section in the data querying guide
* Add `each_n` and `each_s` parameters in the HTTP API  Reference and the guide.