### PR TITLE
RS-312: Optimize tech and meta

### DIFF
--- a/blog/2022-12-17-cpp-sdk-quick-start.mdx
+++ b/blog/2022-12-17-cpp-sdk-quick-start.mdx
@@ -1,5 +1,5 @@
 ---
-title: "How to integrate ReductStore into your C++ application"
+title: "Integrating ReductStore into C++ Applications"
 description: "A quick start guide to integrate ReductStore into your C++ application by using the ReductStore C++ SDK."
 authors: alexey
 tags: [tutorials, sdks]

--- a/blog/2022-12-19-reductstore-v1_2_1-released.mdx
+++ b/blog/2022-12-19-reductstore-v1_2_1-released.mdx
@@ -16,7 +16,7 @@ improve the way tokens and buckets are managed. Specifically, when you create a 
 to ensure that the buckets specified in the token's permissions actually exist. This will help prevent errors and ensure
 that users have the proper access to the appropriate buckets.
 
-<!--truncate-->
+{/* truncate */}
 
 We've also added a new endpoint, `GET /api/v1/me`, which allows users to retrieve their current permissions. This can be
 useful for checking what actions a user is allowed to perform, or for debugging purposes.

--- a/blog/2022-12-20-reduct-cpp-v1_2_0-released.mdx
+++ b/blog/2022-12-20-reduct-cpp-v1_2_0-released.mdx
@@ -13,7 +13,7 @@ includes updated
 documentation after we renamed the project from "Reduct Storage" to "ReductStore", and supports [ReductStore HTTP API
 1.2.0](/docs/http-api) with the endpoint `GET /api/v1/me`.
 
-<!--truncate-->
+{/* truncate */}
 
 One of the useful features of the ReductStore Client SDK is the ability to retrieve information about the authenticated
 user using the `IClient::Me method`. Here is an example of how to use this method:

--- a/blog/2022-12-20-reduct-cpp-v1_2_0-released.mdx
+++ b/blog/2022-12-20-reduct-cpp-v1_2_0-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ReductStore Client SDK for C++ v1.2.0: New Features and Example Use"
+title: "Release of C++ SDK v1.2.0"
 description: Release notes for ReductStore Client SDK for C++ v1.2.0 with usage examples
 authors: alexey
 tags: [news, sdks, tutorials]

--- a/blog/2022-12-22-reduct-py-v1_2_0-released.mdx
+++ b/blog/2022-12-22-reduct-py-v1_2_0-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ReductStore Client SDK for Python v1.2.0: New Features and Example Use"
+title: "Release of Python SDK v1.2.0"
 description: Release notes for ReductStore Client SDK for Python v1.2.0 with usage examples
 authors: alexey
 tags: [news, sdks, tutorials]

--- a/blog/2022-12-22-reduct-py-v1_2_0-released.mdx
+++ b/blog/2022-12-22-reduct-py-v1_2_0-released.mdx
@@ -14,7 +14,7 @@ support for the
 [**ReductStore HTTP API v1.2**](https://github.com/reductstore/reductstore/releases/tag/v1.2.0) and several other
 improvements.
 
-<!--truncate-->
+{/* truncate */}
 
 One of the new features in this release is the `Client.me()` method. This method allows you to get information about the
 current token being used to authenticate with the ReductStore instance. It returns a `FullTokenInfo` object, which

--- a/blog/2022-12-23-reduct-js-v1_2_0-released.mdx
+++ b/blog/2022-12-23-reduct-js-v1_2_0-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ReductStore Client SDK for JavaScript v1.2.0: New Features and Example Use"
+title: "Release of JavaScript SDK v1.2.0"
 description: Release notes for ReductStore Client SDK for JavaScript v1.2.0 with usage examples
 authors: alexey
 tags: [news, sdks, tutorials]

--- a/blog/2022-12-23-reduct-js-v1_2_0-released.mdx
+++ b/blog/2022-12-23-reduct-js-v1_2_0-released.mdx
@@ -13,7 +13,7 @@ JavaScript SDK. This update includes support
 for [**ReductStore API version 1.2**](https://github.com/reductstore/reductstore/releases/tag/v1.2.0) with the
 new `Client.me` method, which allows you to retrieve information about your current API token and its permissions.
 
-<!--truncate-->
+{/* truncate */}
 
 The `Client.me` method is a useful addition to the ReductStore JavaScript SDK, and can help you manage and monitor your
 access to the platform. Here is an example of how you might use it in your application:

--- a/blog/2022-12-26-reduct-cli-v0_4_0-released.mdx
+++ b/blog/2022-12-26-reduct-cli-v0_4_0-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: "CLI Client for ReductStore v0.4.0 has been released"
+title: "Release of CLI Client for v0.4.0"
 description: Release notes for CLI Client for ReductStore v0.4.0 with a new feature to export data to a file system
 authors: alexey
 tags: [news, cli]

--- a/blog/2022-12-26-reduct-cli-v0_4_0-released.mdx
+++ b/blog/2022-12-26-reduct-cli-v0_4_0-released.mdx
@@ -16,7 +16,7 @@ engine to a local folder on your computer.
 This can be useful if you want to make a copy of your data for backup or offline access. For more information, 
 see the [**documentation**](https://cli.reduct.store/en/latest/docs/export/).
 
-<!--truncate-->
+{/* truncate */}
 
 To update to the latest version of the Reduct CLI, use the following command:
 

--- a/blog/2023-01-09-py-sdk-quick-start.mdx
+++ b/blog/2023-01-09-py-sdk-quick-start.mdx
@@ -19,7 +19,7 @@ installed, you can use the `pip` package manager to install the `reduct-py` pack
 pip install reduct-py
 ```
 
-<!--truncate-->
+{/* truncate */}
 
 ## Running ReductStore as a Docker Container
 

--- a/blog/2023-01-15-js-sdk-quick-start.mdx
+++ b/blog/2023-01-15-js-sdk-quick-start.mdx
@@ -20,7 +20,7 @@ installed, you can use the `npm` package manager to install the `reduct-js` pack
 npm install reduct-js
 ```
 
-<!--truncate-->
+{/* truncate */}
 
 ## Running ReductStore as a Docker Container
 

--- a/blog/2023-01-20-reduct-cli-v0_5_0-released.mdx
+++ b/blog/2023-01-20-reduct-cli-v0_5_0-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: "CLI Client for ReductStore v0.5.0 has been released"
+title: "Release of CLI Client for v0.5.0"
 description: Release notes for CLI Client for ReductStore v0.5.0 with new features to improve data export and mirroring
 authors: alexey
 tags: [news, cli]

--- a/blog/2023-01-20-reduct-cli-v0_5_0-released.mdx
+++ b/blog/2023-01-20-reduct-cli-v0_5_0-released.mdx
@@ -23,7 +23,7 @@ useful when a bucket has a large number of entries and the network connection is
 rcli export --parallel 5 folder server_1/bucket_1 . 
 ```
 
-<!--truncate-->
+{/* truncate */}
 
 ### Export or mirror specific entries
 

--- a/blog/2023-01-26-reductstore-v1_3_0-released.mdx
+++ b/blog/2023-01-26-reductstore-v1_3_0-released.mdx
@@ -18,7 +18,7 @@ First and foremost, we've changed the project license, switching from AGPLv3 to 
 as a service over the network in proprietary software. This change is made to avoid any misunderstanding in the future,
 and to align with our goal of encouraging contributions back to the project while allowing everyone to use it for free.
 
-<!--truncate-->
+{/* truncate */}
 
 ## Label Support
 

--- a/blog/2023-01-28-reduct-py-v1_3_0-released.mdx
+++ b/blog/2023-01-28-reduct-py-v1_3_0-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: "New Release of ReductStore Python SDK: v1.3.0: Labels Support and More"
+title: "Release of Python SDK v1.3.0"
 description: "Introducing v1.3.0 of the ReductStore Client SDK for Python: Enhancements to Labels and Content-Type"
 authors: alexey
 tags: [news, sdks, tutorials]

--- a/blog/2023-02-07-reduct-cli-v0_6-released.mdx
+++ b/blog/2023-02-07-reduct-cli-v0_6-released.mdx
@@ -13,7 +13,7 @@ We're excited to announce the release
 of [**version 0.6.0 of the Reduct CLI**](https://github.com/reductstore/reduct-cli/releases/tag/v0.6.0)!
 This release brings a number of new features for working with the new [**ReductStore API v1.3**](/docs/http-api).
 
-<!--truncate-->
+{/* truncate */}
 
 ### File Extensions for Export
 

--- a/blog/2023-02-07-reduct-cli-v0_6-released.mdx
+++ b/blog/2023-02-07-reduct-cli-v0_6-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: CLI Client for ReductStore v0.6.0 has been released
+title: "Release of CLI Client for v0.6.0"
 description: Release notes for CLI Client for ReductStore v0.6.0 with support for the new ReductStore API with labels
 authors: alexey
 tags: [news, cli]

--- a/blog/2023-02-10-reduct-js-v1_3_0-released.mdx
+++ b/blog/2023-02-10-reduct-js-v1_3_0-released.mdx
@@ -25,7 +25,7 @@ const record = await bucket.beginWrite("entry-1", {
 await record.write("Some text");
 ```
 
-<!--truncate-->
+{/* truncate */}
 
 You can use labels to store meta information about records. For example, if it's an image with detected objects, you can store bounding boxes and confidence levels for each object. You can also use labels to filter data in queries:
 

--- a/blog/2023-02-10-reduct-js-v1_3_0-released.mdx
+++ b/blog/2023-02-10-reduct-js-v1_3_0-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: "New Release of ReductStore JavaScript SDK v1.3.0"
+title: "Release of JavaScript SDK v1.3.0"
 description: "Introducing v1.3.0 of the ReductStore Client SDK for JavaScript: Enhancements to Labels and Content-Type"
 authors: alexey
 tags: [news, sdks, tutorials]

--- a/blog/2023-02-19-reduct-cli-v0_7-released.mdx
+++ b/blog/2023-02-19-reduct-cli-v0_7-released.mdx
@@ -22,7 +22,7 @@ wildcards:
 rcli export folder instance/bucket ./export_path  --entries=sensor-*
 ```
 
-<!--truncate-->
+{/* truncate */}
 
 More over, the `rcli export` command used the query API with default TTL 5 seconds for a query. When the internet
 connection was slow, it may have taken more than 5 seconds to request the next record in the query. The query could

--- a/blog/2023-02-19-reduct-cli-v0_7-released.mdx
+++ b/blog/2023-02-19-reduct-cli-v0_7-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: CLI Client for ReductStore v0.7.0 has been released
+title: "Release of CLI Client for v0.7.0"
 description: Release notes for CLI Client for ReductStore v0.7.0 with improved rcli export command.
 authors: alexey
 tags: [news, cli]

--- a/blog/2023-02-22-reduct-cpp-v1_3_0-released.mdx
+++ b/blog/2023-02-22-reduct-cpp-v1_3_0-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ReductStore Client SDK for C++ v1.3.0 with Labels Support"
+title: "Release of C++ SDK v1.3.0"
 description: Release notes for ReductStore Client SDK for C++ v1.3.0 with support for labels and content type
 authors: alexey
 tags: [news, sdks, tutorials]

--- a/blog/2023-02-22-reduct-cpp-v1_3_0-released.mdx
+++ b/blog/2023-02-22-reduct-cpp-v1_3_0-released.mdx
@@ -11,7 +11,7 @@ We are excited to announce the release
 of [**ReductStore Client SDK for C++ v1.3.0**](https://github.com/reductstore/reduct-cpp/releases/tag/v1.3.0)! This release
 includes support for the ReductStore API v1.3.0 with labels and content type.
 
-<!--truncate-->
+{/* truncate */}
 
 ## Labels
 

--- a/blog/2023-03-07-cats-datasets/index.md
+++ b/blog/2023-03-07-cats-datasets/index.md
@@ -1,6 +1,6 @@
 ---
-title: "How to Use 'Cats' dataset with Python ReductStore SDK"
-description: A tutorial on how to download and use the "Cats" dataset with Python ReductStore SDK
+title: "Using Image Dataset with Python SDK"
+description: A tutorial on how to download and use an image dataset with Python ReductStore SDK
 authors: alexey
 tags: [tutorials, computer vision, sdks]
 slug: tutorials/computer-vision/sdks/cats-datasets

--- a/blog/2023-03-09-reduct-cli-v0_8-released.mdx
+++ b/blog/2023-03-09-reduct-cli-v0_8-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: CLI Client for ReductStore v0.8.0 has been released
+title: "Release of CLI Client for v0.8.0"
 description: Release notes for CLI Client for ReductStore v0.8.0 with improved rcli export command.
 authors: alexey
 tags: [news, cli]

--- a/blog/2023-04-05-data-reduction-on-edge.mdx
+++ b/blog/2023-04-05-data-reduction-on-edge.mdx
@@ -1,5 +1,5 @@
 ---
-title: Data Reduction and Why It Is Important For Edge Computing
+title: Importance of Data Reduction for Edge Computing
 description: Data reduction is a critical aspect of edge computing that helps to optimize system efficiency and minimize resource usage. 
 authors: alexey
 tags: [edge-computing]
@@ -11,7 +11,7 @@ Before we dive into the importance of data reduction for edge computing, it is i
 Data reduction refers to the process of reducing the amount of data that needs to be transmitted or stored, while still maintaining the necessary information and level of accuracy. 
 This can be achieved through techniques such as compression, aggregation, and filtering.
 
-<!--truncate-->
+{/* truncate */}
 
 On the other hand, edge computing involves processing data at or near the source rather than transmitting it back to a central location such as a cloud server. 
 This allows for faster processing times and reduced network latency.

--- a/blog/2023-05-09-6-weeks-with-rust.mdx
+++ b/blog/2023-05-09-6-weeks-with-rust.mdx
@@ -1,5 +1,5 @@
 ---
-title: 6 weeks with Rust
+title: The Bottom Line After 6 Weeks With Rust
 description: a post about my experience with migrating ReductStore from C++ to Rust
 authors: alexey
 tags: [news]

--- a/blog/2023-06-04-subscription-cpp.mdx
+++ b/blog/2023-06-04-subscription-cpp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Subscribe to new records with ReductStore C++ SDK
+title: Subscribe to new records with C++ SDK
 description: The example code demonstrates how to use the C++ Reduct SDK to subscribe to new records from a bucket.
 authors: alexey
 tags: [tutorials, sdks]

--- a/blog/2023-06-09-reductstore-v1_4_0-released.mdx
+++ b/blog/2023-06-09-reductstore-v1_4_0-released.mdx
@@ -11,7 +11,7 @@ I am happy to announce that we have completed the migration from C++ to Rust, an
 
 It was not an easy journey. After six weeks of coding, we encountered numerous regressions and changes in behavior. I needed to release two alpha and two beta versions with production testing to clean up the database. Now, it is finally ready!
 
-<!--truncate-->
+{/* truncate */}
 
 ## Breaking changes
 

--- a/blog/2023-07-02-reductstore-v1_5_0-released.mdx
+++ b/blog/2023-07-02-reductstore-v1_5_0-released.mdx
@@ -17,7 +17,7 @@ I'm happy to announce that the [**next minor version**](https://github.com/reduc
 
 Let me show you how it works in detail and how you can use it.
 
-<!--truncate-->
+{/* truncate */}
 
 ## Batching Records
 

--- a/blog/2023-08-15-reductstore-v1_6_0-released.mdx
+++ b/blog/2023-08-15-reductstore-v1_6_0-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ReductStore 1.6.0 has been released with new license and client SDK for Rust"
+title: "Release v1.6.0: license and client SDK for Rust"
 description: The article announces the release of ReductStore 1.6.0, a time-series database designed for managing large amounts of blob data. The update includes a new license, client SDK for Rust, and new features in HTTP API 1.6.0.
 authors: alexey
 tags: [news]

--- a/blog/2023-08-15-reductstore-v1_6_0-released.mdx
+++ b/blog/2023-08-15-reductstore-v1_6_0-released.mdx
@@ -19,7 +19,7 @@ We have updated the ReductStore license to the Business Source License (BUSL-1.1
 
 We believe that the new license strikes a good balance between freedom and revenue generation. This balance is necessary to maintain and improve our technology, and to bring benefits to its users.
 
-<!--truncate-->
+{/* truncate */}
 
 ## Client SDK for Rust
 

--- a/blog/2023-09-13-reductstore-benchmark/index.md
+++ b/blog/2023-09-13-reductstore-benchmark/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ReductStore vs. MinIO & InfluxDB on LTE Network: Who Really Wins the Speed Race?"
+title: "Benchmark against MinIO and InfluxDB"
 description: The article presents the result of benchmrking ReductStore vs. MinIO and InfluxDB on an edge device.
 authors: anthony
 tags: [comparison, iot]

--- a/blog/2023-10-09-reductstore-v1_7_0-released.mdx
+++ b/blog/2023-10-09-reductstore-v1_7_0-released.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ReductStore v1.7.0 has been released with provisioning and batch writing"
+title: "Release v1.7.0: Provisioning & Batch Writing"
 description: ReductStore v1.7.0 introduces two new features that make it easier to provision resources and write data in batches, which can improve your performance and efficiency when using ReductStore for edge computing and AI applications.
 authors: alexey
 tags: [news]

--- a/blog/2023-10-09-reductstore-v1_7_0-released.mdx
+++ b/blog/2023-10-09-reductstore-v1_7_0-released.mdx
@@ -16,7 +16,7 @@ To download the latest released version, please visit our [**Download Page**](ht
 ReductStore v1.7.0 introduces two new features that make it easier to provision resources and write data in batches, which can improve your performance and efficiency when using ReductStore for edge computing and AI applications.
 
 
-<!--truncate-->
+{/* truncate */}
 
 ## Provisioning With Environment Variables
 

--- a/blog/2023-10-15-Implementing-open-source-ai-anomaly-detection/index.md
+++ b/blog/2023-10-15-Implementing-open-source-ai-anomaly-detection/index.md
@@ -1,5 +1,5 @@
 ---
-title: "From Lab to Live: Implementing Open-Source AI Models for Real-Time Unsupervised Anomaly Detection in Images"
+title: "Implementing AI for Real-Time Anomaly Detection in Images"
 description: Explore the process of deploying open-source AI models for real-time image anomaly detection, bridging the gap between research and practical applications.
 authors: anthony
 tags: [computer vision, edge computing, ai]

--- a/blog/2023-12-08-open-source-alternatives-to-landing-ai/index.md
+++ b/blog/2023-12-08-open-source-alternatives-to-landing-ai/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Exploring Open-Source Alternatives to Landing AI for Robust MLOps"
+title: "Open-Source Alternatives to Landing AI"
 description: Discover top open-source alternatives to Landing AI in this insightful blog. We delve into essential MLOps tools for data labeling, model training, and more. Enhance your AI projects with platforms like COCO Annotator, Ultralytics, and MLflow.
 authors: anthony
 tags: [computer vision, ai, mlops, open source]
@@ -135,4 +135,4 @@ For edge computing needs similar to what LandingEdge provides, especially when d
 
 These tools all bring something to the table, showing why it's key to choose a set that fits our operational needs and tech limits. It's all about making sure that the stack aligns with operational requirements and technological constraints.
 
-Thanks for reading! If you're interested in learning more about how to use open-source AI models for real-time, unsupervised anomaly detection in images, don't miss our blog titled [**"From Lab to Live: Implementing Open-Source AI Models for Real-Time Unsupervised Anomaly Detection in Images."**](/blog/computer-vision/edge-computing/ai/Implementing-open-source-ai-anomaly-detection)
+Thanks for reading! If you're interested in learning more about how to use open-source AI models for real-time, unsupervised anomaly detection in images, don't miss our blog titled [**"Implementing AI for Real-Time Anomaly Detection in Images."**](/blog/computer-vision/edge-computing/ai/Implementing-open-source-ai-anomaly-detection)

--- a/blog/2023-12-19-how-to-keep-mqtt-data-node.mdx
+++ b/blog/2023-12-19-how-to-keep-mqtt-data-node.mdx
@@ -1,5 +1,5 @@
 ---
-title: "How to Keep a History of MQTT Data With Node.js"
+title: "Keeping MQTT Data History with Node.js"
 description: "A tutorial to keep a history of MQTT messages with Node.js by using the ReductStore Client SDK for JavaScript."
 authors: alexey
 tags: [tutorials, iot, mqtt]

--- a/blog/2024-01-13-implement-data-streaming-pytorch/index.md
+++ b/blog/2024-01-13-implement-data-streaming-pytorch/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How To Implement Data Streaming In PyTorch From A Remote Database"
+title: "Implementing Data Streaming in PyTorch from Remote DB"
 description: Discover how to implement data streaming in your PyTorch project from a remote database. This blog provides a practical approach to setting up a custom PyTorch's IterableDataset that reads data from a time series database.
 authors: anthony
 tags: [ai, datastreaming, pytorch]

--- a/blog/2024-01-19-kafka-tutorial/index.md
+++ b/blog/2024-01-19-kafka-tutorial/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Easy Guide to Integrating Kafka: Practical Solutions for Managing Blob Data"
+title: "Kafka Integration Tutorial for Blob Data"
 description: This tutorial offers a simple approach to combining Apache Kafka with ReductStore for handling data streams from edge devices. We'll cover the basics of setting up Kafka and ReductStore using Docker, creating Kafka topics in Python, and managing blob data and metadata.
 authors: anthony
 tags: [tutorials, datastreaming, kafka]

--- a/blog/2024-01-28-reductstore-v1_8_0-released/index.md
+++ b/blog/2024-01-28-reductstore-v1_8_0-released/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Reductstore 1.8.0 Released: Introducing Data Replication"
+title: "Release v1.8.0: Introducing Data Replication"
 description: ReductStore v1.8.0 introduces data replication between ReductStore instances.
 authors: alexey
 tags: [news]

--- a/blog/2024-02-16-3-ways-stora-data-for-computer-vision-applications/index.mdx
+++ b/blog/2024-02-16-3-ways-stora-data-for-computer-vision-applications/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "3 Ways To Store Data in Computer Vision Applications"
+title: "3 Ways to Store Computer Vision Data"
 description: "Learn how to store data in computer vision applications by using ReductStore, S3-like storage or a file system."
 authors: alexey
 tags: [tutorials, computer vision]

--- a/blog/2024-03-16-ROS-integration/index.md
+++ b/blog/2024-03-16-ROS-integration/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Optimal Image Storage Solutions for ROS-Based Computer Vision"
+title: "How to Store Images in ROS 2"
 description: "This blog post will guide you through setting up ROS 2 with ReductStore—a time-series database optimized for unstructured data. More specifically, we'll go through a practical example to show how to capture and store raw camera images from a ROS topic in ReductStore."
 authors: anthony
 tags: [tutorials, ros, computer vision]

--- a/blog/2024-03-27-reductstore-vs-timescale/index.md
+++ b/blog/2024-03-27-reductstore-vs-timescale/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Time Series Blob Data: ReductStore vs. TimescaleDB"
+title: "Alternative to TimescaleDB for Blob Data"
 description: "A comparison of ReductStore and TimescaleDB for storing time series blob data."
 authors: alexey
 tags: [comparisons, iot]

--- a/blog/2024-04-08-reductstore-vs-mongodb/index.md
+++ b/blog/2024-04-08-reductstore-vs-mongodb/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Time Series Blob Data: ReductStore vs. MongoDB"
+title: "Alternative to MongoDB for Blob Data"
 description: "A comparison of ReductStore and MongoDB for storing time series blob data."
 authors: anthony
 tags: [comparisons, iot]

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -8,7 +8,7 @@ description: ReductStore configuration options and provisioning.
   <link rel="canonical" href="https://www.reduct.store/docs/configuration" />
 </head>
 
-# ⚙ Configuration
+# ⚙ Server Configuration and Provisioning
 
 ## Settings
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -8,7 +8,7 @@ description: Getting started with ReductStore database and how to integrate it i
   <link rel="canonical" href="https://www.reduct.store/docs/getting-started" />
 </head>
 
-# 🚀 Getting Started
+# 🚀 Getting Started with ReductStore
 
 ReductStore offers many ways to easily integrate into an existing infrastructure. Choose the one that suits you best.
 

--- a/docs/guides/access-control.mdx
+++ b/docs/guides/access-control.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <head>
-    <link rel="canonical" href="https://www.reduct.store/docs/guides/access-management"/>
+    <link rel="canonical" href="https://www.reduct.store/docs/guides/access-control"/>
 </head>
 
 # Access Control

--- a/docs/guides/buckets.mdx
+++ b/docs/guides/buckets.mdx
@@ -12,7 +12,7 @@ import CodeBlock from "@theme/CodeBlock";
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Buckets
+# ReductStore Bucket Guide
 
 Buckets are the primary storage unit in ReductStore. They are used to group data entries and define the storage settings for the data. This guide will cover the concepts of buckets, their settings, and operations like creating, browsing, changing settings, and removing buckets.
 

--- a/docs/guides/data-ingestion.mdx
+++ b/docs/guides/data-ingestion.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
     <link rel="canonical" href="https://www.reduct.store/docs/guides/data-ingestion"/>
 </head>
 
-# Data Ingestion
+# Data Ingestion With ReductStore
 
 Data ingestion is the process of collecting, transferring, and loading data into a system. In ReductStore, data ingestion is the first step in storing data. This guide provides an overview of data ingestion in ReductStore and explains how to ingest data using the ReductStore SDKs or the HTTP API.
 

--- a/docs/guides/data-querying.mdx
+++ b/docs/guides/data-querying.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
     <link rel="canonical" href="https://www.reduct.store/docs/guides/data-querying"/>
 </head>
 
-# Data Querying
+# Data Querying From ReductStore Database
 
 ReductStore is a time series database that provides efficient data retrieval capabilities. This guide explains how to query data from ReductStore using the CLI, HTTP API, and SDKs.
 

--- a/docs/guides/data-replication.mdx
+++ b/docs/guides/data-replication.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
     <link rel="canonical" href="https://www.reduct.store/docs/guides/data-replication"/>
 </head>
 
-# Data Replication
+# Data Replication With ReductStore
 
 Data replication is a process of copying data from one database to another. ReductStore provides simple and efficient append-only replication to stream data from one bucket to another one.
 

--- a/docs/how-does-it-work.mdx
+++ b/docs/how-does-it-work.mdx
@@ -8,7 +8,7 @@ description: ReductStore basic concepts like buckets, entries, blocks, records, 
   <link rel="canonical" href="https://www.reduct.store/docs/how-does-it-work" />
 </head>
 
-# 💡 Basic Concepts
+# 💡 Basic Concepts Behind ReductStore
 
 ## What Is Time Series Blob Storage?
 

--- a/docs/http-api/bucket-api.mdx
+++ b/docs/http-api/bucket-api.mdx
@@ -10,7 +10,7 @@ description: Bucket API allows users to create, modify, and delete buckets.
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Bucket API
+# Bucket API Specification Reference
 
 The Bucket API allows users to create, modify, and delete buckets.
 

--- a/docs/http-api/entry-api.mdx
+++ b/docs/http-api/entry-api.mdx
@@ -10,7 +10,7 @@ description: The Entry API allows users to write and read data from their bucket
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Entry API
+# Entry API Specification Reference
 
 
 The Entry API allows users to write and read data from their buckets, as well as search for specific entries using query operations.

--- a/docs/http-api/replication-api.mdx
+++ b/docs/http-api/replication-api.mdx
@@ -10,7 +10,7 @@ description: The API for managing replications
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Replication API
+# Replication API Specification Reference
 
 :::info
 Since version 1.8.0, ReductStore supports append-only replication. This feature allows replicating data from one bucket to another.

--- a/docs/http-api/server-api.mdx
+++ b/docs/http-api/server-api.mdx
@@ -10,7 +10,7 @@ description: The server API provides HTTP methods for checking the status of the
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Server API
+# Server API Specification Reference
 
 The server API provides HTTP methods for checking the status of the server, listing the available buckets, and retrieving the permissions for the current API token.
 

--- a/docs/http-api/token-authentication.mdx
+++ b/docs/http-api/token-authentication.mdx
@@ -10,7 +10,7 @@ description: The API for managing access tokens and permissions for the database
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Token API
+# Token API Specification Reference
 
 :::info
 The database uses the token authentication when the RS_API_TOKEN environment is set. You should use it as a full access token to create other tokens with different permission by using the Token API

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,8 +57,7 @@ const config = {
           editUrl: "https://github.com/reductstore/docs/tree/main",
         },
         blog: {
-          blogTitle:
-            "ReductStore Blog: Insights on edge computing, computer vision, and IoT",
+          blogTitle: "Blog | Time-Series Object Store for Edge Computing",
           blogDescription:
             "Welcome to ReductStore's Blog – your source for expert articles, updates, and discussions on managing and leveraging time series databases for blob data in edge computing, computer vision, and IoT. Stay informed with our latest content.",
           blogSidebarTitle: "Recent posts",

--- a/src/components/HomepageCTA/index.tsx
+++ b/src/components/HomepageCTA/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 function HomepageCTA() {
   return (
     <section className={styles.section}>
-      <Heading as="h1">AI on the Edge? Download our White Paper</Heading>
+      <Heading as="h2">AI on the Edge? Download our White Paper</Heading>
       <p >
         Learn more about ReductStore and how it can help you simplify your data infrastructure and AI/ML workflows.
       </p>

--- a/src/components/HomepageFaqs/index.tsx
+++ b/src/components/HomepageFaqs/index.tsx
@@ -7,7 +7,7 @@ import Link from "@docusaurus/Link";
 export default function HomepageFaqs() {
   return (
     <section className={styles.section}>
-      <Heading as="h1" className={styles.sectionTitle}>Frequently Asked Questions</Heading>
+      <Heading as="h2" className={styles.sectionTitle}>Frequently Asked Questions</Heading>
       <Faq faqs={landingFaqs} defaultOpenCount={3} />
     </section>
   );

--- a/src/components/SimpleHeader/index.tsx
+++ b/src/components/SimpleHeader/index.tsx
@@ -1,16 +1,18 @@
 import React from "react";
 import styles from "./styles.module.css";
+import Heading from '@theme/Heading';
 
 interface SimpleHeaderProps {
   pageTitle: string;
+  pageTitleAs?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   subtitle?: string;
 }
 
-function SimpleHeader({ pageTitle, subtitle }: SimpleHeaderProps) {
+function SimpleHeader({ pageTitle, pageTitleAs, subtitle }: SimpleHeaderProps) {
   return (
     <header className={styles.Banner}>
       <div className="container">
-        <h1 className={styles.BannerTitle}>{pageTitle}</h1>
+        <Heading as={pageTitleAs || "h1"} className={styles.BannerTitle}>{pageTitle}</Heading>
         {subtitle && <p className={styles.BannerSubtitle}>{subtitle}</p>}
       </div>
     </header>

--- a/src/pages/contact/index.tsx
+++ b/src/pages/contact/index.tsx
@@ -7,11 +7,11 @@ import styles from './styles.module.css';
 export default function ContactPage() {
   return (
     <Layout
-      title="Contact Us"
+      title="Contact Us for More Information"
       description="Reach out to the ReductStore team for support, inquiries, or feedback. We're here to help you with any questions you may have."
     >
       <main>
-        <SimpleHeader pageTitle="Contact Us" />
+        <SimpleHeader pageTitle="Talk With Our Team" />
         <div className="container">
           <p className={styles.introText}>
             Whether you're experiencing problems, have questions about our products, or just want to say hello, our dedicated team is here to help.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,7 +60,7 @@ function HomepageHeader() {
 export default function Home(): JSX.Element {
   return (
     <Layout
-      title="Time-Series Object Store for Edge Computing and AI/ML Workflows"
+      title="Time-Series Object Store for Edge Computing"
       description="ReductStore is a time series database designed specifically for storing and managing large amounts of unstructured data. 
       It offers high performance for writing and real-time querying, making it suitable for edge computing, computer vision, and IoT applications."
     >

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -27,7 +27,7 @@ export default function Pricing(): JSX.Element {
           <PricingTable />
         </div>
         <br />
-        <SimpleHeader pageTitle="Frequently Asked Questions" />
+        <SimpleHeader pageTitle="Frequently Asked Questions" pageTitleAs="h2" />
         <div className="container">
           <Faq faqs={pricingFaqs} defaultOpenCount={3} />
         </div>

--- a/src/pages/use-cases/index.tsx
+++ b/src/pages/use-cases/index.tsx
@@ -8,11 +8,11 @@ import styles from './styles.module.css';
 export default function UseCases(): JSX.Element {
   return (
     <Layout
-      title="Explore Use Cases"
+      title="Explore Use Case Scenarios"
       description="Learn how our solutions can help you transform your infrastructure."
     >
       <main>
-        <SimpleHeader pageTitle="Explore Use Cases" />
+        <SimpleHeader pageTitle="Explore Use Case Scenarios for ReductStore" />
 
         <div className={clsx("container", styles.useCasesContainer)}>
 

--- a/src/pages/whitepaper/index.tsx
+++ b/src/pages/whitepaper/index.tsx
@@ -14,7 +14,7 @@ export default function ReductAI(): JSX.Element {
   } = useDocusaurusContext();
   return (
     <Layout
-      title="White Paper: AI Infrastructure for Edge Computing"
+      title="AI Infrastructure for Edge Computing"
       description="Dive into our white paper to learn more about our approach to building and deploying AI models on the edge."
     >
       <main>

--- a/versioned_docs/version-1.7.x/configuration.mdx
+++ b/versioned_docs/version-1.7.x/configuration.mdx
@@ -8,7 +8,7 @@ description: ReductStore configuration options and provisioning.
   <link rel="canonical" href="https://www.reduct.store/docs/configuration" />
 </head>
 
-# ⚙ Configuration
+# ⚙ Server Configuration and Provisioning
 
 ## Settings
 

--- a/versioned_docs/version-1.7.x/http-api/bucket-api.mdx
+++ b/versioned_docs/version-1.7.x/http-api/bucket-api.mdx
@@ -10,7 +10,7 @@ description: Bucket API allows users to create, modify, and delete buckets.
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Bucket API
+# Bucket API Specification Reference
 
 The Bucket API allows users to create, modify, and delete buckets.
 

--- a/versioned_docs/version-1.7.x/http-api/entry-api.mdx
+++ b/versioned_docs/version-1.7.x/http-api/entry-api.mdx
@@ -10,7 +10,7 @@ description: The Entry API allows users to write and read data from their bucket
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Entry API
+# Entry API Specification Reference
 
 
 The Entry API allows users to write and read data from their buckets, as well as search for specific entries using query operations.

--- a/versioned_docs/version-1.7.x/http-api/server-api.mdx
+++ b/versioned_docs/version-1.7.x/http-api/server-api.mdx
@@ -10,7 +10,7 @@ description: The server API provides HTTP methods for checking the status of the
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Server API
+# Server API Specification Reference
 
 The server API provides HTTP methods for checking the status of the server, listing the available buckets, and retrieving the permissions for the current API token.
 

--- a/versioned_docs/version-1.7.x/http-api/token-authentication.mdx
+++ b/versioned_docs/version-1.7.x/http-api/token-authentication.mdx
@@ -10,7 +10,7 @@ description: The API for managing access tokens and permissions for the database
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Token API
+# Token API Specification Reference
 
 :::info
 The database uses the token authentication when the RS_API_TOKEN environment is set. You should use it as a full access token to create other tokens with different permission by using the Token API

--- a/versioned_docs/version-1.8.x/configuration.mdx
+++ b/versioned_docs/version-1.8.x/configuration.mdx
@@ -8,7 +8,7 @@ description: ReductStore configuration options and provisioning.
   <link rel="canonical" href="https://www.reduct.store/docs/configuration" />
 </head>
 
-# ⚙ Configuration
+# ⚙ Server Configuration and Provisioning
 
 ## Settings
 

--- a/versioned_docs/version-1.8.x/http-api/bucket-api.mdx
+++ b/versioned_docs/version-1.8.x/http-api/bucket-api.mdx
@@ -10,7 +10,7 @@ description: Bucket API allows users to create, modify, and delete buckets.
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Bucket API
+# Bucket API Specification Reference
 
 The Bucket API allows users to create, modify, and delete buckets.
 

--- a/versioned_docs/version-1.8.x/http-api/entry-api.mdx
+++ b/versioned_docs/version-1.8.x/http-api/entry-api.mdx
@@ -10,7 +10,7 @@ description: The Entry API allows users to write and read data from their bucket
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Entry API
+# Entry API Specification Reference
 
 
 The Entry API allows users to write and read data from their buckets, as well as search for specific entries using query operations.

--- a/versioned_docs/version-1.8.x/http-api/replication-api.mdx
+++ b/versioned_docs/version-1.8.x/http-api/replication-api.mdx
@@ -10,7 +10,7 @@ description: The API for managing replications
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Replication API
+# Replication API Specification Reference
 
 :::info
 Since version 1.8.0, ReductStore supports append-only replication. This feature allows replicating data from one bucket to another.

--- a/versioned_docs/version-1.8.x/http-api/server-api.mdx
+++ b/versioned_docs/version-1.8.x/http-api/server-api.mdx
@@ -10,7 +10,7 @@ description: The server API provides HTTP methods for checking the status of the
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Server API
+# Server API Specification Reference
 
 The server API provides HTTP methods for checking the status of the server, listing the available buckets, and retrieving the permissions for the current API token.
 

--- a/versioned_docs/version-1.8.x/http-api/token-authentication.mdx
+++ b/versioned_docs/version-1.8.x/http-api/token-authentication.mdx
@@ -10,7 +10,7 @@ description: The API for managing access tokens and permissions for the database
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Token API
+# Token API Specification Reference
 
 :::info
 The database uses the token authentication when the RS_API_TOKEN environment is set. You should use it as a full access token to create other tokens with different permission by using the Token API

--- a/versioned_docs/version-1.9.x/configuration.mdx
+++ b/versioned_docs/version-1.9.x/configuration.mdx
@@ -8,7 +8,7 @@ description: ReductStore configuration options and provisioning.
   <link rel="canonical" href="https://www.reduct.store/docs/configuration" />
 </head>
 
-# ⚙ Configuration
+# ⚙ Server Configuration and Provisioning
 
 ## Settings
 

--- a/versioned_docs/version-1.9.x/getting-started.mdx
+++ b/versioned_docs/version-1.9.x/getting-started.mdx
@@ -8,7 +8,7 @@ description: Getting started with ReductStore database and how to integrate it i
   <link rel="canonical" href="https://www.reduct.store/docs/getting-started" />
 </head>
 
-# 🚀 Getting Started
+# 🚀 Getting Started with ReductStore
 
 ReductStore offers many ways to easily integrate into an existing infrastructure. Choose the one that suits you best.
 

--- a/versioned_docs/version-1.9.x/guides/access-control.mdx
+++ b/versioned_docs/version-1.9.x/guides/access-control.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <head>
-    <link rel="canonical" href="https://www.reduct.store/docs/guides/access-management"/>
+    <link rel="canonical" href="https://www.reduct.store/docs/guides/access-control"/>
 </head>
 
 # Access Control

--- a/versioned_docs/version-1.9.x/guides/buckets.mdx
+++ b/versioned_docs/version-1.9.x/guides/buckets.mdx
@@ -12,7 +12,7 @@ import CodeBlock from "@theme/CodeBlock";
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Buckets
+# ReductStore Bucket Guide
 
 Buckets are the primary storage unit in ReductStore. They are used to group data entries and define the storage settings for the data. This guide will cover the concepts of buckets, their settings, and operations like creating, browsing, changing settings, and removing buckets.
 

--- a/versioned_docs/version-1.9.x/guides/data-ingestion.mdx
+++ b/versioned_docs/version-1.9.x/guides/data-ingestion.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
     <link rel="canonical" href="https://www.reduct.store/docs/guides/data-ingestion"/>
 </head>
 
-# Data Ingestion
+# Data Ingestion With ReductStore
 
 Data ingestion is the process of collecting, transferring, and loading data into a system. In ReductStore, data ingestion is the first step in storing data. This guide provides an overview of data ingestion in ReductStore and explains how to ingest data using the ReductStore SDKs or the HTTP API.
 

--- a/versioned_docs/version-1.9.x/guides/data-querying.mdx
+++ b/versioned_docs/version-1.9.x/guides/data-querying.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
     <link rel="canonical" href="https://www.reduct.store/docs/guides/data-querying"/>
 </head>
 
-# Data Querying
+# Data Querying From ReductStore Database
 
 ReductStore is a time series database that provides efficient data retrieval capabilities. This guide explains how to query data from ReductStore using the CLI, HTTP API, and SDKs.
 

--- a/versioned_docs/version-1.9.x/guides/data-replication.mdx
+++ b/versioned_docs/version-1.9.x/guides/data-replication.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
     <link rel="canonical" href="https://www.reduct.store/docs/guides/data-replication"/>
 </head>
 
-# Data Replication
+# Data Replication With ReductStore
 
 Data replication is a process of copying data from one database to another. ReductStore provides simple and efficient append-only replication to stream data from one bucket to another one.
 

--- a/versioned_docs/version-1.9.x/how-does-it-work.mdx
+++ b/versioned_docs/version-1.9.x/how-does-it-work.mdx
@@ -8,7 +8,7 @@ description: ReductStore basic concepts like buckets, entries, blocks, records, 
   <link rel="canonical" href="https://www.reduct.store/docs/how-does-it-work" />
 </head>
 
-# 💡 Basic Concepts
+# 💡 Basic Concepts Behind ReductStore
 
 ## What Is Time Series Blob Storage?
 

--- a/versioned_docs/version-1.9.x/http-api/bucket-api.mdx
+++ b/versioned_docs/version-1.9.x/http-api/bucket-api.mdx
@@ -10,7 +10,7 @@ description: Bucket API allows users to create, modify, and delete buckets.
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Bucket API
+# Bucket API Specification Reference
 
 The Bucket API allows users to create, modify, and delete buckets.
 

--- a/versioned_docs/version-1.9.x/http-api/entry-api.mdx
+++ b/versioned_docs/version-1.9.x/http-api/entry-api.mdx
@@ -10,7 +10,7 @@ description: The Entry API allows users to write and read data from their bucket
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Entry API
+# Entry API Specification Reference
 
 
 The Entry API allows users to write and read data from their buckets, as well as search for specific entries using query operations.

--- a/versioned_docs/version-1.9.x/http-api/replication-api.mdx
+++ b/versioned_docs/version-1.9.x/http-api/replication-api.mdx
@@ -10,7 +10,7 @@ description: The API for managing replications
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Replication API
+# Replication API Specification Reference
 
 :::info
 Since version 1.8.0, ReductStore supports append-only replication. This feature allows replicating data from one bucket to another.

--- a/versioned_docs/version-1.9.x/http-api/server-api.mdx
+++ b/versioned_docs/version-1.9.x/http-api/server-api.mdx
@@ -10,7 +10,7 @@ description: The server API provides HTTP methods for checking the status of the
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Server API
+# Server API Specification Reference
 
 The server API provides HTTP methods for checking the status of the server, listing the available buckets, and retrieving the permissions for the current API token.
 

--- a/versioned_docs/version-1.9.x/http-api/token-authentication.mdx
+++ b/versioned_docs/version-1.9.x/http-api/token-authentication.mdx
@@ -10,7 +10,7 @@ description: The API for managing access tokens and permissions for the database
 
 import SwaggerComponent from "@site/src/components/SwaggerComponent";
 
-# Token API
+# Token API Specification Reference
 
 :::info
 The database uses the token authentication when the RS_API_TOKEN environment is set. You should use it as a full access token to create other tokens with different permission by using the Token API


### PR DESCRIPTION
- Fixed a canonical link
- Fixed MDX formatting issue with truncate (only issue with formatting in code editor)
- Updated problematic page titles (too long; duplicated keywords)
  - Duplicate & Too long example: "**ReductStore** vs. MinIO & InfluxDB on LTE Network: Who Really Wins the Speed Race? | **ReductStore**" (updated around 30 page titles.. let's see if it helps)
- Updated titles that were too short
  - aside page titles, we had 20 h1 tags that were too short (e.g. 🚀 Getting Started)
- Solved heading issues
  - found some pages with multiple h1 tags