### PR TITLE
RS-310: add links to guide and API reference categories

### DIFF
--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -1,0 +1,19 @@
+---
+sidebar_position: 3
+title: 📃 Guides
+description: Guides for using ReductStore with SDKs and other tools.
+---
+
+<head>
+  <link rel="canonical" href="https://www.reduct.store/docs/guides" />
+</head>
+
+#  📃 Guides
+
+This section contains guides for using ReductStore with SDKs and other tools.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/sidebars.json
+++ b/sidebars.json
@@ -8,6 +8,10 @@
             "label": "Guides",
             "collapsed": false,
             "collapsible": false,
+            "link": {
+              "type": "doc",
+              "id": "guides/index"
+            },
             "items": [
                 "guides/buckets",
                 "guides/data-ingestion",
@@ -26,8 +30,11 @@
         {
             "type": "category",
             "label": "API Reference",
+            "link":  {
+              "type": "doc",
+              "id": "http-api/index"
+            },
             "items": [
-                "http-api/index",
                 "http-api/server-api",
                 "http-api/bucket-api",
                 "http-api/entry-api",


### PR DESCRIPTION
*  The "Gudes" and "API References" items are clickable