### PR TITLE
RS-311: Update docs for new replication settings

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -90,6 +90,8 @@ ReductStore provides an HTTP API to create and configure resources such as bucke
 | `RS_REPLICATION_<ID>_ENTRIES`       |         | List of entries to replicate. Separate entries with a comma. If the list is empty, all entries will be replicated. |
 | `RS_REPLICATION_<ID>_INCLUDE_<KEY>` |         | Replicate only records with KEY equal to the value of the environment variable. Can be used multiple times.        |
 | `RS_REPLICATION_<ID>_EXCLUDE_<KEY>` |         | Do not replicate records with KEY equal to the value of the environment variable. Can be used multiple times.      |
+| `RS_REPLICATION_<ID>_EACH_S`        |         | Replicate a record every S seconds. Can have a floating-point value.                                               |
+| `RS_REPLICATION_<ID>_EACH_N`        |         | Replicate every N-th record.                                                                                       |
 
 :::tip
 You can use any string value for `<ID>`. It is only used to group resources of the same type.

--- a/docs/guides/data-querying.mdx
+++ b/docs/guides/data-querying.mdx
@@ -32,15 +32,16 @@ are divided into two categories: filter and control parameters.
 ### Filter Parameters
 
 Filter parameters are used to select records based on specific criteria. You can combine multiple filter parameters to create complex queries. This is the list of filter parameters, sorted by priority:
-| Parameter | Description                     | Type            | Default                                        |
-|-----------|---------------------------------|-----------------|------------------------------------------------|
-| `start`   | Start time of the query         | Timestamp       | The timestamp of the first record in the entry |
-| `end`     | End time of the query           | Timestamp       | The timestamp of the last record in the entry  |
-| `include` | List of label values to include | List of strings | Disabled                                       |
-| `exclude` | List of labels to exclude       | List of strings | Disabled                                       |
-| `each_s`  | Return a record every S seconds | Float           | Disabled                                       |
-| `each_n`  | Return only every N record      | Integer         | Disabled                                       |
-| `limit`   | Limit on the number of records  | Integer         | All records are returned                       |
+
+| Parameter | Description                     | Type                    | Default                                        |
+|-----------|---------------------------------|-------------------------|------------------------------------------------|
+| `start`   | Start time of the query         | Timestamp               | The timestamp of the first record in the entry |
+| `end`     | End time of the query           | Timestamp               | The timestamp of the last record in the entry  |
+| `include` | List of label values to include | List of key-value pairs | Disabled                                       |
+| `exclude` | List of labels to exclude       | List of key-value pairs | Disabled                                       |
+| `each_s`  | Return a record every S seconds | Float                   | Disabled                                       |
+| `each_n`  | Return only every N record      | Integer                 | Disabled                                       |
+| `limit`   | Limit on the number of records  | Integer                 | All records are returned                       |
 
 **Time Range**
 

--- a/docs/guides/data-replication.mdx
+++ b/docs/guides/data-replication.mdx
@@ -32,9 +32,16 @@ This approach ensures that data is replicated in real time and that the replicat
 
 A replication task can filter records before replicating them to the target bucket. You can specify the following filters:
 
-* **Include Labels**: A list of key-value pairs that the replication task will use to filter records. Only records with these labels will be replicated.
-* **Exclude Labels**: A list of key-value pairs that the replication task will use to filter records. Records with these labels will not be replicated.
-* **Entries**: A list of entries that the Replication Task will use to filter records. Only records with these entries will be replicated. If the list is empty, all records will be replicated. You can use the `*` wildcard to match any entry.
+
+| Parameter | Description                                                                                                                                                                                                                        | Type                    |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
+| `entries` | A list of entries that the replication task will use to filter records. Only records with these entries will be replicated. If the list is empty, all records will be replicated. You can use the `*` wildcard to match any entry. | List of strings         |
+| `include` | A list of key-value pairs that the replication task will use to filter records. Only records with these labels will be replicated.                                                                                                 | List of key-value pairs |
+| `exclude` | A list of key-value pairs that the replication task will use to filter records. Records with these labels will not be replicated.                                                                                                  | List of key-value pairs |
+| `each_s`  | Replicate a record every S seconds                                                                                                                                                                                                 | Float                   |
+| `each_n`  | Replicate only every N record                                                                                                                                                                                                      | Integer                 |
+
+
 
 ## Managing Data Replication Tasks
 

--- a/docs/guides/data-replication.mdx
+++ b/docs/guides/data-replication.mdx
@@ -41,7 +41,25 @@ A replication task can filter records before replicating them to the target buck
 | `each_s`  | Replicate a record every S seconds                                                                                                                                                                                                 | Float                   |
 | `each_n`  | Replicate only every N record                                                                                                                                                                                                      | Integer                 |
 
+### Usage Example
 
+Data replication may seem complex, but it is actually quite simple. Let's take a simple example:
+
+Imagine we collect high frequency vibration sensor data from an engine in the `sensor-data` bucket.
+The data from each sensor is stored in a separate record.
+We want to replicate only the data from the `sensor-1` entry to the `remote-data` bucket in another ReductStore instance.
+However, we only want to replicate the records if the engine is working and the sensor data is not corrupted.
+In this case, the conditional replication settings will be:
+
+```yaml
+entries: ["sensor-1"]
+include:
+  engine_status: "working"
+exclude:
+  sensor_status: "corrupted"
+```
+
+See the next section for more information on how to create a replication task with conditional replication settings.
 
 ## Managing Data Replication Tasks
 

--- a/docs/http-api/replication-api.mdx
+++ b/docs/http-api/replication-api.mdx
@@ -111,6 +111,8 @@ The replication is performed in the background and doesn't affect the performanc
             "exclude": {
                 "string": "string"        // key-value pairs to exclude records that should not be replicated. If empty, all records will be replicated
             },
+            "each_s": "float",            // replicate a record every S seconds
+            "each_n": "int",              // replicate every Nth record
         },
 }`}</code></pre>
       )
@@ -213,7 +215,25 @@ The replication is performed in the background and doesn't affect the performanc
         isRequired: false,
         description: "Key-value pairs to exclude records that should not be replicated. If empty, all records will be replicated"
       }
-    }
+    },
+    {
+      type: "body",
+      details: {
+        name: "each_s",
+        dataType: "Float",
+        isRequired: false,
+        description: "Replicate a record every S seconds"
+      }
+    },
+    {
+      type: "body",
+      details: {
+        name: "each_n",
+        dataType: "Integer",
+        isRequired: false,
+        description: "Replicate every Nth record"
+      }
+    },
   ]}
   responses={[
     {
@@ -325,7 +345,25 @@ The replication is performed in the background and doesn't affect the performanc
         isRequired: false,
         description: "Key-value pairs to exclude records that should not be replicated. If empty, all records will be replicated"
       }
-    }
+    },
+    {
+      type: "body",
+      details: {
+        name: "each_s",
+        dataType: "Float",
+        isRequired: false,
+        description: "Replicate a record every S seconds"
+      }
+    },
+    {
+      type: "body",
+      details: {
+        name: "each_n",
+        dataType: "Integer",
+        isRequired: false,
+        description: "Replicate every Nth record"
+      }
+    },
   ]}
   responses={[
     {


### PR DESCRIPTION
Add information about the `each_n` and `each_s` replication params to:

* Replication guide
* Configuration section
* HTTP API Reference

See reductstore/reductstore#480