### PR TITLE
Document rename endpoints

### DIFF
--- a/docs/http-api/bucket-api.mdx
+++ b/docs/http-api/bucket-api.mdx
@@ -144,6 +144,10 @@ parameters are empty.
 If authentication is enabled, the method needs a valid API token with full
 access.
 
+**Changes**:
+
+- v1.12: HARD quota type was introduced.
+
 <SwaggerComponent
   method="POST"
   path="/api/v1/b/:bucket_name"
@@ -231,6 +235,10 @@ with all the settings.
 
 If authentication is enabled, the method needs a valid API token with full access.
 
+**Changes**:
+
+- v1.12: HARD quota type was introduced.
+
 <SwaggerComponent
   method="PUT"
   path="/api/v1/b/:bucket_name"
@@ -266,7 +274,7 @@ If authentication is enabled, the method needs a valid API token with full acces
       type: "body",
       details: {
         name: "quota_type",
-        description: "Type of quota. Can have values 'NONE' or 'FIFO'",
+        description: "Type of quota. Can have values 'NONE', 'FIFO' or 'HARD'",
         dataType: "String",
         isRequired: false,
       },
@@ -306,6 +314,73 @@ If authentication is enabled, the method needs a valid API token with full acces
       status: "409",
       message: "Conflict",
       summary: "Bucket is provisioned",
+    },
+    {
+      status: "422",
+      message: "Unprocessable Entity",
+      summary: "JSON request is invalid",
+    },
+  ]}
+/>
+
+## Rename a Bucket
+
+To rename a bucket, the request should have a JSON document with the new name.
+
+If authentication is enabled, the method needs a valid API token with full access.
+
+**Changes**:
+
+- v1.12: the endpoint was introduced.
+
+<SwaggerComponent
+  method="PUT"
+  path="/api/v1/b/:bucket_name/rename"
+  summary="Rename a bucket"
+  parameters={[
+    {
+      type: "path",
+      details: {
+        name: ":bucket_name",
+        description: "Name of bucket",
+        isRequired: true,
+      },
+    },
+    {
+      type: "body",
+      details: {
+        name: "new_name",
+        description: "New name of the bucket",
+        dataType: "String",
+        isRequired: true,
+      },
+    },
+  ]}
+  responses={[
+    {
+      status: "200",
+      message: "OK",
+      summary: "The bucket is renamed",
+    },
+    {
+      status: "401",
+      message: "Unauthorized",
+      summary: "Access token is invalid or empty",
+    },
+    {
+      status: "403",
+      message: "Forbidden",
+      summary: "Access token doesn't have enough permissions",
+    },
+    {
+      status: "404",
+      message: "Not Found",
+      summary: "Bucket doesn't exist",
+    },
+    {
+      status: "409",
+      message: "Conflict",
+      summary: "Bucket with the new name already exists",
     },
     {
       status: "422",

--- a/docs/http-api/entry-api/update_data.mdx
+++ b/docs/http-api/entry-api/update_data.mdx
@@ -73,7 +73,7 @@ if authentication is enabled.
     {
       type: "header",
       details: {
-        name: "x-reduct-label-<name>",
+        name: "x-reduct-label-[name]",
         description: "A value of a label assigned to the record",
         isRequired: false,
       },
@@ -84,13 +84,6 @@ if authentication is enabled.
       status: "200",
       message: "OK",
       summary: "The record is written",
-      description: (
-        <pre>
-          <code>{`{
-    // Response
-}`}</code>
-        </pre>
-      ),
     },
     {
       status: "400",
@@ -162,6 +155,81 @@ Existing labels not mentioned in the request stay unchanged.
       status: "422",
       message: "Unprocessable Entity",
       summary: "Bad header format",
+    },
+  ]}
+/>
+
+## Rename an Entry
+
+To rename an entry, the request should have a JSON document with the new name.
+
+If authentication is enabled, the method needs a valid API token with full access.
+
+**Changes**:
+
+- Version 1.12: The method was introduced.
+
+<SwaggerComponent
+  method="PUT"
+  path="/api/v1/b/:bucket_name/:entry_name/rename"
+  summary="Rename an entry"
+  parameters={[
+    {
+      type: "path",
+      details: {
+        name: ":bucket_name",
+        description: "Name of bucket",
+        isRequired: true,
+      },
+    },
+    {
+      type: "path",
+      details: {
+        name: ":entry_name",
+        description: "Name of entry",
+        isRequired: true,
+      },
+    },
+    {
+      type: "body",
+      details: {
+        name: "new_name",
+        description: "New name of the entry",
+        dataType: "String",
+        isRequired: true,
+      },
+    },
+  ]}
+  responses={[
+    {
+      status: "200",
+      message: "OK",
+      summary: "The entry is renamed",
+    },
+    {
+      status: "401",
+      message: "Unauthorized",
+      summary: "Access token is invalid or empty",
+    },
+    {
+      status: "403",
+      message: "Forbidden",
+      summary: "Access token doesn't have enough permissions",
+    },
+    {
+      status: "404",
+      message: "Not Found",
+      summary: "Bucket or entry doesn't exist",
+    },
+    {
+      status: "409",
+      message: "Conflict",
+      summary: "Entry with the new name already exists",
+    },
+    {
+      status: "422",
+      message: "Unprocessable Entity",
+      summary: "JSON request is invalid",
     },
   ]}
 />


### PR DESCRIPTION
Add documentation for:
 * Renaming a bucket endpoint
 *  * Renaming an input endpoint

 I didn't create a section in the guides. I think these are not very important features and quite simple, and users can find them in the SDKs documentation or the tools.