### PR TITLE
RS-529: document comparison operators

### DIFF
--- a/docs/conditional-query/comparison-operators.mdx
+++ b/docs/conditional-query/comparison-operators.mdx
@@ -14,14 +14,14 @@ The comparison operators are used to compare values in a query.
 
 The following comparison operators are supported:
 
-| Operator | Description                                                                 |
-| -------- | --------------------------------------------------------------------------- |
-| `$eq`    | Equal. Returns true if the values are equal.                                |
-| `$ne`    | Not equal. Returns true if the values are not equal.                        |
-| `$gt`    | Greater than. Returns true if the first value is greater than the second.   |
-| `$gte`   | Greater than or equal. Returns true if the first value is greater or equal. |
-| `$lt`    | Less than. Returns true if the first value is less than the second.         |
-| `$lte`   | Less than or equal. Returns true if the first value is less or equal.       |
+| Operator | Description                                                                                 |
+| -------- | ------------------------------------------------------------------------------------------- |
+| `$eq`    | Equal. Returns true if the values are equal.                                                |
+| `$ne`    | Not equal. Returns true if the values are not equal.                                        |
+| `$gt`    | Greater than. Returns true if the first value is greater than the second.                   |
+| `$gte`   | Greater than or equal. Returns true if the first value is greater than the second or equal. |
+| `$lt`    | Less than. Returns true if the first value is less than the second.                         |
+| `$lte`   | Less than or equal. Returns true if the first value is less than the second or equal.       |
 
 ## $eq
 

--- a/docs/conditional-query/comparison-operators.mdx
+++ b/docs/conditional-query/comparison-operators.mdx
@@ -2,3 +2,227 @@
 title: Comparison Operators
 description: Learn how to use comparison operators in conditional queries to filter data in ReductStore.
 ---
+
+<head>
+  <link
+    rel="canonical"
+    href="https://www.reduct.store/docs/conditional-query/comparison-operators"
+  />
+</head>
+
+The comparison operators are used to compare values in a query.
+
+The following comparison operators are supported:
+
+| Operator | Description                                                                 |
+| -------- | --------------------------------------------------------------------------- |
+| `$eq`    | Equal. Returns true if the values are equal.                                |
+| `$ne`    | Not equal. Returns true if the values are not equal.                        |
+| `$gt`    | Greater than. Returns true if the first value is greater than the second.   |
+| `$gte`   | Greater than or equal. Returns true if the first value is greater or equal. |
+| `$lt`    | Less than. Returns true if the first value is less than the second.         |
+| `$lte`   | Less than or equal. Returns true if the first value is less or equal.       |
+
+## $eq
+
+The `$eq` operator is used to compare values for equality.
+
+### Syntax
+
+```
+{
+  "$eq": [ <expression_1>, <expression_2> ]
+}
+```
+
+### Behavior
+
+The operator returns true if the values of the two expressions are equal.
+
+### Examples
+
+Object notation:
+
+```json
+{
+  "&label_name": { "$eq": 10 }
+}
+```
+
+Array notation:
+
+```json
+{
+  "$eq": ["&label_name", 10]
+}
+```
+
+## $ne
+
+The `$ne` operator is used to compare values for inequality.
+
+### Syntax
+
+```
+{
+  "$ne": [ <expression_1>, <expression_2> ]
+}
+```
+
+### Behavior
+
+The operator returns true if the values of the two expressions are not equal.
+
+### Examples
+
+Object notation:
+
+```json
+{
+  "&label_name": { "$ne": 10 }
+}
+```
+
+Array notation:
+
+```json
+{
+  "$ne": ["&label_name", 10]
+}
+```
+
+## $gt
+
+The `$gt` operator is used to compare values for greater than.
+
+### Syntax
+
+```
+{
+  "$gt": [ <expression_1>, <expression_2> ]
+}
+```
+
+### Behavior
+
+The operator returns true if the value of the first expression is greater than the value of the second expression.
+
+### Examples
+
+Object notation:
+
+```json
+{
+  "&label_name": { "$gt": 10 }
+}
+```
+
+Array notation:
+
+```json
+{
+  "$gt": ["&label_name", 10]
+}
+```
+
+## $gte
+
+The `$gte` operator is used to compare values for greater than or equal.
+
+### Syntax
+
+```
+{
+  "$gte": [ <expression_1>, <expression_2> ]
+}
+```
+
+### Behavior
+
+The operator returns true if the value of the first expression is greater than or equal to the value of the second expression.
+
+### Examples
+
+Object notation:
+
+```json
+{
+  "&label_name": { "$gte": 10 }
+}
+```
+
+Array notation:
+
+```json
+{
+  "$gte": ["&label_name", 10]
+}
+```
+
+## $lt
+
+The `$lt` operator is used to compare values for less than.
+
+### Syntax
+
+```
+{
+  "$lt": [ <expression_1>, <expression_2> ]
+}
+```
+
+### Behavior
+
+The operator returns true if the value of the first expression is less than the value of the second expression.
+
+### Examples
+
+Object notation:
+
+```json
+{
+  "&label_name": { "$lt": 10 }
+}
+```
+
+Array notation:
+
+```json
+{
+  "$lt": ["&label_name", 10]
+}
+```
+
+## $lte
+
+The `$lte` operator is used to compare values for less than or equal.
+
+### Syntax
+
+```
+{
+  "$lte": [ <expression_1>, <expression_2> ]
+}
+```
+
+### Behavior
+
+The operator returns true if the value of the first expression is less than or equal to the value of the second expression.
+
+### Examples
+
+Object notation:
+
+```json
+{
+  "&label_name": { "$lte": 10 }
+}
+```
+
+Array notation:
+
+```json
+{
+  "$lte": ["&label_name", 10]
+}
+```

--- a/docs/conditional-query/logical-operators.mdx
+++ b/docs/conditional-query/logical-operators.mdx
@@ -30,8 +30,8 @@ The `$and` or `$all_of` operator is used to combine multiple conditions in a que
 ```
 {
   "$and" | "$all_of: [
-    { expression_1 },
-    { expression_2},
+    { <expression_1> },
+    { <expression_2> },
     ...
   ]
 }
@@ -73,8 +73,8 @@ The `$or` or `$any_of` operator is used to combine multiple conditions in a quer
 ```
 {
   "$or" | "$any_of": [
-    { expression_1 },
-    { expression_2},
+    { <expression_1> },
+    { <expression_2>},
     ...
   ]
 }
@@ -115,8 +115,8 @@ The `$xor` or `$one_of` operator is used to combine multiple conditions in a que
 ```
 {
   "$xor" | "$one_of": [
-    { expression_1 },
-    { expression_2 },
+    { <expression_1> },
+    { <expression_2> },
     ...
   ]
 }
@@ -157,8 +157,8 @@ The `$not` or `$none_of` operator is used to negate a condition in a query. The 
 ```
 {
   "$not" | "$none_of": [
-    { expression_1 },
-    { expression_2 },
+    { <expression_1> },
+    { <expression_2> },
   ]
 }
 ```

--- a/docs/http-api/entry-api/delete_data.mdx
+++ b/docs/http-api/entry-api/delete_data.mdx
@@ -186,7 +186,7 @@ If authentication is enabled, the method needs a valid API token with read acces
 - Version 1.12: the method was introduced.
 
 :::warning
-Since version 1.13, te method is deprecated. Use the [**Query API**](/docs/http-api/entry-api/run_query.mdx) instead.
+Since version 1.13, the method is deprecated. Use the [**Query API**](/docs/http-api/entry-api/run_query.mdx) instead.
 :::
 
 <SwaggerComponent

--- a/docs/http-api/entry-api/read_data.mdx
+++ b/docs/http-api/entry-api/read_data.mdx
@@ -231,7 +231,7 @@ access to the bucket of the entry.
 - Version 1.10: the method has the `each_n` and `each_s` query parameters. If the `each_n` parameter is set, the method returns only every `each_n`-th record. If the `each_s` parameter is set, the method returns only one record per `each_s` seconds.
 
 :::warning
-Since version 1.13, te method is deprecated. Use the [**Query API**](/docs/http-api/entry-api/run_query.mdx) instead.
+Since version 1.13, the method is deprecated. Use the [**Query API**](/docs/http-api/entry-api/run_query.mdx) instead.
 :::
 
 <SwaggerComponent

--- a/docs/http-api/entry-api/run_query.mdx
+++ b/docs/http-api/entry-api/run_query.mdx
@@ -102,10 +102,12 @@ The request body should be a JSON object with the following parameters:
 
     // Optional. A list of labels to include in the query.
     // Only records with all the specified labels are included.
+    // DEPRECATED: Use "when" instead.
     include?: "Dict[string, string]"
 
     // Optional. A list of labels to exclude in the query.
     // Records with any of the specified labels are excluded.
+    // DEPRECATED: Use "when" instead.
     exclude?: "Dict[string, string]"
 
     // Optional. A conditional query to filter records.


### PR DESCRIPTION
* Document comparison operators in the conditional query
* Include/exclude options are deprecated