### PR TITLE
RS-575: Fix query examples for Python

### DIFF
--- a/blog/2024-06-11-reductstore-v1_10_0-released.mdx
+++ b/blog/2024-06-11-reductstore-v1_10_0-released.mdx
@@ -39,7 +39,7 @@ async def main():
     bucket: Bucket = await client.get_bucket("my-bucket")
 
     # Query every 10-th record in the "vibration-sensor-1" entry of the bucket
-    async for record in bucket.query("vibration-sensor-1", start="2024-06-11T00:00:00Z", end="2024-06-11T01:00:00Z", each_n=10):
+    async for record in bucket.query("vibration-sensor-1", start="2024-06-11T00:00:00Z", stop="2024-06-11T01:00:00Z", each_n=10):
         # Read the record content
         content = await record.read_all()
         print(content)

--- a/docs/examples/py/src/data_querying_time_range.py
+++ b/docs/examples/py/src/data_querying_time_range.py
@@ -16,7 +16,7 @@ async def main():
         )
 
         # Query records in the "py-example" entry of the bucket
-        async for record in bucket.query("py-example", start=ts, end=ts + 1):
+        async for record in bucket.query("py-example", start=ts, stop=ts + 1):
             # Print  meta information
             print(f"Timestamp: {record.timestamp}")
             print(f"Content Length: {record.size}")

--- a/docs/examples/py/src/quick_start.py
+++ b/docs/examples/py/src/quick_start.py
@@ -20,7 +20,7 @@ async def main():
         # 4. Query the data by time range and condition
         async for record in bucket.query("sensor-1",
                                          start="2024-01-01T10:00:00Z",
-                                         end="2024-01-01T10:00:02Z",
+                                         stop="2024-01-01T10:00:02Z",
                                          when={"&score": {"$gt": 10}}):
             print(f"Record timestamp: {record.timestamp}")
             print(f"Record size: {record.size}")

--- a/docs/sdk/py/index.mdx
+++ b/docs/sdk/py/index.mdx
@@ -64,7 +64,7 @@ async def main():
         # 4. Query the data by time range and condition
         async for record in bucket.query("sensor-1",
                                          start="2024-01-01T10:00:00Z",
-                                         end="2024-01-01T10:00:02Z",
+                                         stop="2024-01-01T10:00:02Z",
                                          when={"&score": {"$gt": 10}}):
             print(f"Record timestamp: {record.timestamp}")
             print(f"Record size: {record.size}")

--- a/versioned_docs/version-1.10.x/examples/py/src/data_querying_time_range.py
+++ b/versioned_docs/version-1.10.x/examples/py/src/data_querying_time_range.py
@@ -16,7 +16,7 @@ async def main():
     )
 
     # Query records in the "py-example" entry of the bucket
-    async for record in bucket.query("py-example", start=ts, end=ts + 1):
+    async for record in bucket.query("py-example", start=ts, stop=ts + 1):
         # Print  meta information
         print(f"Timestamp: {record.timestamp}")
         print(f"Content Length: {record.size}")

--- a/versioned_docs/version-1.10.x/examples/py/src/quick_start.py
+++ b/versioned_docs/version-1.10.x/examples/py/src/quick_start.py
@@ -17,7 +17,7 @@ async def main():
 
         # 4. Query the data by time range
         async for record in bucket.query(
-            "sensor-1", start="2024-01-01T10:00:00Z", end="2024-01-01T10:00:02Z"
+            "sensor-1", start="2024-01-01T10:00:00Z", stop="2024-01-01T10:00:02Z"
         ):
             print(f"Record timestamp: {record.timestamp}")
             print(f"Record size: {record.size}")

--- a/versioned_docs/version-1.11.x/examples/py/src/quick_start.py
+++ b/versioned_docs/version-1.11.x/examples/py/src/quick_start.py
@@ -17,7 +17,7 @@ async def main():
 
         # 4. Query the data by time range
         async for record in bucket.query(
-            "sensor-1", start="2024-01-01T10:00:00Z", end="2024-01-01T10:00:02Z"
+            "sensor-1", start="2024-01-01T10:00:00Z", stop="2024-01-01T10:00:02Z"
         ):
             print(f"Record timestamp: {record.timestamp}")
             print(f"Record size: {record.size}")

--- a/versioned_docs/version-1.12.x/examples/py/src/data_querying_time_range.py
+++ b/versioned_docs/version-1.12.x/examples/py/src/data_querying_time_range.py
@@ -16,7 +16,7 @@ async def main():
         )
 
         # Query records in the "py-example" entry of the bucket
-        async for record in bucket.query("py-example", start=ts, end=ts + 1):
+        async for record in bucket.query("py-example", start=ts, stop=ts + 1):
             # Print  meta information
             print(f"Timestamp: {record.timestamp}")
             print(f"Content Length: {record.size}")

--- a/versioned_docs/version-1.12.x/examples/py/src/quick_start.py
+++ b/versioned_docs/version-1.12.x/examples/py/src/quick_start.py
@@ -17,7 +17,7 @@ async def main():
 
         # 4. Query the data by time range
         async for record in bucket.query(
-            "sensor-1", start="2024-01-01T10:00:00Z", end="2024-01-01T10:00:02Z"
+            "sensor-1", start="2024-01-01T10:00:00Z", stop="2024-01-01T10:00:02Z"
         ):
             print(f"Record timestamp: {record.timestamp}")
             print(f"Record size: {record.size}")

--- a/versioned_docs/version-1.13.x/examples/py/src/data_querying_time_range.py
+++ b/versioned_docs/version-1.13.x/examples/py/src/data_querying_time_range.py
@@ -16,7 +16,7 @@ async def main():
         )
 
         # Query records in the "py-example" entry of the bucket
-        async for record in bucket.query("py-example", start=ts, end=ts + 1):
+        async for record in bucket.query("py-example", start=ts, stop=ts + 1):
             # Print  meta information
             print(f"Timestamp: {record.timestamp}")
             print(f"Content Length: {record.size}")

--- a/versioned_docs/version-1.13.x/examples/py/src/quick_start.py
+++ b/versioned_docs/version-1.13.x/examples/py/src/quick_start.py
@@ -20,7 +20,7 @@ async def main():
         # 4. Query the data by time range and condition
         async for record in bucket.query("sensor-1",
                                          start="2024-01-01T10:00:00Z",
-                                         end="2024-01-01T10:00:02Z",
+                                         stop="2024-01-01T10:00:02Z",
                                          when={"&score": {"$gt": 10}}):
             print(f"Record timestamp: {record.timestamp}")
             print(f"Record size: {record.size}")

--- a/versioned_docs/version-1.13.x/sdk/py/index.mdx
+++ b/versioned_docs/version-1.13.x/sdk/py/index.mdx
@@ -64,7 +64,7 @@ async def main():
         # 4. Query the data by time range and condition
         async for record in bucket.query("sensor-1",
                                          start="2024-01-01T10:00:00Z",
-                                         end="2024-01-01T10:00:02Z",
+                                         stop="2024-01-01T10:00:02Z",
                                          when={"&score": {"$gt": 10}}):
             print(f"Record timestamp: {record.timestamp}")
             print(f"Record size: {record.size}")

--- a/versioned_docs/version-1.9.x/examples/py/src/data_querying_time_range.py
+++ b/versioned_docs/version-1.9.x/examples/py/src/data_querying_time_range.py
@@ -16,7 +16,7 @@ async def main():
     )
 
     # Query records in the "py-example" entry of the bucket
-    async for record in bucket.query("py-example", start=ts, end=ts + 1):
+    async for record in bucket.query("py-example", start=ts, stop=ts + 1):
         # Print  meta information
         print(f"Timestamp: {record.timestamp}")
         print(f"Content Length: {record.size}")


### PR DESCRIPTION
* rename the `end` parameter to `stop` in Bucket.query 