### PR TITLE
Document changes in conditional query operators

### DIFF
--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -17,6 +17,7 @@ jobs:
       max-parallel: 8
       matrix:
         example: [python, node, curl, cpp, rust, cli]
+        doc_version: [next, 1.14.x, 1.13.x, 1.12.x]
         include:
           - doc_version: next
             reduct_version: main

--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       max-parallel: 8
       matrix:
-        doc_version: [next, 1.14.x, 1.13.x, 1.12.x, 1.11.x, 1.10.x]
         example: [python, node, curl, cpp, rust, cli]
         include:
           - doc_version: next
@@ -34,14 +33,6 @@ jobs:
           - doc_version: 1.12.x
             reduct_version: v1.12.0
             example_root: versioned_docs/version-1.12.x/examples/
-
-          - doc_version: 1.11.x
-            reduct_version: v1.11.2
-            example_root: versioned_docs/version-1.11.x/examples/
-
-          - doc_version: 1.10.x
-            reduct_version: v1.10.1
-            example_root: versioned_docs/version-1.10.x/examples/
 
           - language: python
             cmd: python3

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,6 @@
 docs/sdk/
+versioned_docs/version-1.7.x
+versioned_docs/version-1.8.x
+versioned_docs/version-1.9.x
+versioned_docs/version-1.10.x
+versioned_docs/version-1.11.x

--- a/docs/conditional-query/aggregation-operators.mdx
+++ b/docs/conditional-query/aggregation-operators.mdx
@@ -43,7 +43,7 @@ Filter records with a score greater than 10, then return every 5th record from t
 ```json
 {
   "&score": { "$gt": 10 },
-  "$each_n": [5]
+  "$each_n": 5
 }
 ```
 
@@ -51,7 +51,7 @@ Select every 5th record, then return those with a score greater than 10:
 
 ```json
 {
-  "$each_n": [5],
+  "$each_n": 5,
   "&score": { "$gt": 10 }
 }
 ```
@@ -79,7 +79,7 @@ Filter records with a score greater than 10, then return only those that are at 
 ```json
 {
   "&score": { "$gt": 10 },
-  "$each_t": [5]
+  "$each_t": 5
 }
 ```
 
@@ -87,7 +87,7 @@ Keep only records at least 5 seconds apart, then filter for scores greater than 
 
 ```json
 {
-  "$each_t": [5],
+  "$each_t": 5,
   "&score": { "$gt": 10 }
 }
 ```
@@ -116,7 +116,7 @@ Limit the number of records whose score is greater than 10 to 5:
 ```json
 {
   "&score": { "$gt": 10 },
-  "$limit": [5]
+  "$limit": 5
 }
 ```
 
@@ -124,7 +124,7 @@ Find records with a score greater than 10 in the first 5 records:
 
 ```json
 {
-  "$limit": [5],
+  "$limit": 5,
   "&score": { "$gt": 10 }
 }
 ```

--- a/docs/conditional-query/aggregation-operators.mdx
+++ b/docs/conditional-query/aggregation-operators.mdx
@@ -1,0 +1,48 @@
+---
+title: Aggregation Operators
+description: Learn how to use aggregation operators to aggregate data in ReductStore.
+---
+
+<head>
+  <link
+    rel="canonical"
+    href="https://www.reduct.store/docs/conditional-query/aggregation-operators"
+  />
+</head>
+
+The aggregation operators are used to aggregate data in a **[conditional query](../glossary#conditional-query)**.
+
+The following aggregation operators are supported:
+
+| Operator  | Description                                     |
+| --------- | ----------------------------------------------- |
+| `$each_n` | Keeps each N-th record after previous condition |
+
+## $each_n
+
+The `$each_n` operator is used to keep each N-th record after the previous condition.
+
+### Syntax
+
+```
+{
+  "$each_n": [
+    { <expression as integer> }
+  ]
+}
+```
+
+### Behavior
+
+The operator evaluates the first expression as an integer and uses it to determine the step size for keeping records.
+
+### Examples
+
+Array notation:
+
+```json
+{
+  "&score": { "$gt": 10 },
+  "$each_n": [5] // Keep every 5th record whose score is greater than 10
+}
+```

--- a/docs/conditional-query/aggregation-operators.mdx
+++ b/docs/conditional-query/aggregation-operators.mdx
@@ -38,7 +38,7 @@ The operator evaluates the first expression as an integer and uses it to determi
 
 ### Examples
 
-Find records with a score greater than 10 and return every 5th record:
+Filter records with a score greater than 10, then return every 5th record from the result:
 
 ```json
 {

--- a/docs/conditional-query/aggregation-operators.mdx
+++ b/docs/conditional-query/aggregation-operators.mdx
@@ -47,7 +47,7 @@ Filter records with a score greater than 10, then return every 5th record from t
 }
 ```
 
-Filter out records that are not every 5th record and then return records with a score greater than 10:
+Select every 5th record, then return those with a score greater than 10:
 
 ```json
 {

--- a/docs/conditional-query/aggregation-operators.mdx
+++ b/docs/conditional-query/aggregation-operators.mdx
@@ -74,7 +74,7 @@ The operator evaluates the first expression as a float and uses it to determine 
 
 ### Examples
 
-Find records with a score greater than 10 and return ones that are 5 seconds apart:
+Filter records with a score greater than 10, then return only those that are at least 5 seconds apart.
 
 ```json
 {

--- a/docs/conditional-query/aggregation-operators.mdx
+++ b/docs/conditional-query/aggregation-operators.mdx
@@ -28,9 +28,7 @@ The `$each_n` operator is used to keep each N-th record after the previous condi
 
 ```
 {
-  "$each_n": [
-    { <expression as integer> }
-  ]
+  "$each_n": [ <expression as integer> ]
 }
 ```
 
@@ -66,9 +64,7 @@ The `$each_t` operator is used to keep a record if its timestamp is greater than
 
 ```
 {
-  "$each_t": [
-    { <expression as float> }
-  ]
+  "$each_t": [ <expression as float> ]
 }
 ```
 
@@ -104,9 +100,7 @@ The `$limit` operator is used to limit the number of records to be processed in 
 
 ```
 {
-  "$limit": [
-    { <expression as integer> }
-  ]
+  "$limit": [ <expression as integer> ]
 }
 ```
 

--- a/docs/conditional-query/aggregation-operators.mdx
+++ b/docs/conditional-query/aggregation-operators.mdx
@@ -58,7 +58,7 @@ Select every 5th record, then return those with a score greater than 10:
 
 ## $each_t
 
-The `$each_t` operator is used to keep a record if its timestamp is greater than the previous condition in the given time in seconds.
+The `$each_t` operator keeps a record if its timestamp is at least the specified number of seconds after the previous matching record.
 
 ### Syntax
 

--- a/docs/conditional-query/aggregation-operators.mdx
+++ b/docs/conditional-query/aggregation-operators.mdx
@@ -14,9 +14,10 @@ The aggregation operators are used to aggregate data in a **[conditional query](
 
 The following aggregation operators are supported:
 
-| Operator  | Description                                     |
-| --------- | ----------------------------------------------- |
-| `$each_n` | Keeps each N-th record after previous condition |
+| Operator  | Description                                                         |
+| --------- | ------------------------------------------------------------------- |
+| `$each_n` | Keeps each N-th record after previous condition                     |
+| `$each_t` | Keeps a record after the previous condition once in every N seconds |
 
 ## $each_n
 
@@ -44,5 +45,34 @@ Array notation:
 {
   "&score": { "$gt": 10 },
   "$each_n": [5] // Keep every 5th record whose score is greater than 10
+}
+```
+
+## $each_t
+
+The `$each_t` operator is used to keep a record if its timestamp is greater than the previous condition in the given time in seconds.
+
+### Syntax
+
+```
+{
+  "$each_t": [
+    { <expression as float> }
+  ]
+}
+```
+
+### Behavior
+
+The operator evaluates the first expression as a float and uses it to determine the time in seconds for keeping records.
+
+### Examples
+
+Array notation:
+
+```json
+{
+  "&timestamp": { "$gt": 10 },
+  "$each_t": [5] // Keep a record once in every 5 seconds whose score is greater than 10
 }
 ```

--- a/docs/conditional-query/aggregation-operators.mdx
+++ b/docs/conditional-query/aggregation-operators.mdx
@@ -18,6 +18,7 @@ The following aggregation operators are supported:
 | --------- | ------------------------------------------------------------------- |
 | `$each_n` | Keeps each N-th record after previous condition                     |
 | `$each_t` | Keeps a record after the previous condition once in every N seconds |
+| `$limit`  | Limits the number of records to be processed in the query           |
 
 ## $each_n
 
@@ -39,12 +40,21 @@ The operator evaluates the first expression as an integer and uses it to determi
 
 ### Examples
 
-Array notation:
+Find records with a score greater than 10 and return every 5th record:
 
 ```json
 {
   "&score": { "$gt": 10 },
-  "$each_n": [5] // Keep every 5th record whose score is greater than 10
+  "$each_n": [5]
+}
+```
+
+Filter out records that are not every 5th record and then return records with a score greater than 10:
+
+```json
+{
+  "$each_n": [5],
+  "&score": { "$gt": 10 }
 }
 ```
 
@@ -68,11 +78,59 @@ The operator evaluates the first expression as a float and uses it to determine 
 
 ### Examples
 
-Array notation:
+Find records with a score greater than 10 and return ones that are 5 seconds apart:
 
 ```json
 {
-  "&timestamp": { "$gt": 10 },
-  "$each_t": [5] // Keep a record once in every 5 seconds whose score is greater than 10
+  "&score": { "$gt": 10 },
+  "$each_t": [5]
+}
+```
+
+Filter out records that are less than 5 seconds apart and then return records with a score greater than 10:
+
+```json
+{
+  "$each_t": [5],
+  "&score": { "$gt": 10 }
+}
+```
+
+## $limit
+
+The `$limit` operator is used to limit the number of records to be processed in the query.
+
+### Syntax
+
+```
+{
+  "$limit": [
+    { <expression as integer> }
+  ]
+}
+```
+
+### Behavior
+
+The operator evaluates the first expression as an integer and uses it to limit the number of records to be processed in the query.
+The operator is applied after the previous condition, so it limits the number of records that match the previous condition.
+
+### Examples
+
+Limit the number of records whose score is greater than 10 to 5:
+
+```json
+{
+  "&score": { "$gt": 10 },
+  "$limit": [5]
+}
+```
+
+Find records with a score greater than 10 in the first 5 records:
+
+```json
+{
+  "$limit": [5],
+  "&score": { "$gt": 10 }
 }
 ```

--- a/docs/conditional-query/aggregation-operators.mdx
+++ b/docs/conditional-query/aggregation-operators.mdx
@@ -83,7 +83,7 @@ Filter records with a score greater than 10, then return only those that are at 
 }
 ```
 
-Filter out records that are less than 5 seconds apart and then return records with a score greater than 10:
+Keep only records at least 5 seconds apart, then filter for scores greater than 10:
 
 ```json
 {

--- a/docs/conditional-query/index.mdx
+++ b/docs/conditional-query/index.mdx
@@ -79,7 +79,7 @@ This is the same as:
 The conditions are evaluated in the order they are defined, and the result is true only if all conditions are true.
 By default, a condition is evaluated at the stage of data retrieval, so the storage engine will not read the record if the condition is false.
 
-However, if a condition has a [**computed label**](./glossary#computed-label), the engine will check the condition after the record has been read and processed by [**extensions**](./glossary#computed-label).
+However, if a condition has a [**computed label**](./glossary#computed-label), the engine will check the condition after the record has been read and processed by [**extensions**](./glossary#extensions).
 For example, if you have a condition like this:
 
 ```javascript

--- a/docs/conditional-query/index.mdx
+++ b/docs/conditional-query/index.mdx
@@ -57,6 +57,14 @@ The array notation is more flexible and allows you to have more than two operand
 }
 ```
 
+For unary operators the array can be replaced with a single value:
+
+```json
+{
+  "$not": "&label_name"
+}
+```
+
 ### Multiple conditions
 
 The query object can contain multiple conditions that are linked using the AND operator:
@@ -82,7 +90,7 @@ By default, a condition is evaluated at the stage of data retrieval, so the stor
 However, if a condition has a [**computed label**](./glossary#computed-label), the engine will check the condition after the record has been read and processed by [**extensions**](./glossary#extensions).
 For example, if you have a condition like this:
 
-```javascript
+```json
 {
   "&object_number": { "$gt": 10 },
   "@anomaly_score": { "$gt": 0.5 }

--- a/docs/conditional-query/index.mdx
+++ b/docs/conditional-query/index.mdx
@@ -87,7 +87,7 @@ This is the same as:
 The conditions are evaluated in the order they are defined, and the result is true only if all conditions are true.
 By default, a condition is evaluated at the stage of data retrieval, so the storage engine will not read the record if the condition is false.
 
-However, if a condition has a [**computed label**](./glossary#computed-label), the engine will check the condition after the record has been read and processed by [**extensions**](./glossary#extensions).
+However, if a condition has a [**computed label**](./glossary#computed-label), the engine will check the condition after the record has been read and processed by [**extensions**](./glossary#extension).
 For example, if you have a condition like this:
 
 ```json

--- a/docs/conditional-query/misc-operators.mdx
+++ b/docs/conditional-query/misc-operators.mdx
@@ -5,11 +5,12 @@ description: Learn how to use miscellaneous operators to filter data in ReductSt
 
 Besides the main categories of operators, ReductStore supports a few miscellaneous operators that provide additional functionality:
 
-| Operator            | Description                                         |
-| ------------------- | --------------------------------------------------- |
-| `$has` \| `$exists` | Checks if a record has specific labels.             |
-| `$cast`             | Casts a label value to a different type explicitly. |
-| `$ref`              | References a label value in a record explicitly.    |
+| Operator              | Description                                                         |
+| --------------------- | ------------------------------------------------------------------- |
+| `$has` \| `$exists`   | Checks if a record has specific labels.                             |
+| `$cast`               | Casts a label value to a different type explicitly.                 |
+| `$ref`                | References a label value in a record explicitly.                    |
+| `$timestamp` \| `$id` | Retrieves the timestamp of a record as a UNIX time in microseconds. |
 
 ## $has | $exists
 
@@ -123,5 +124,40 @@ Using an expression to reference a label:
 ```json
 {
   "$ref": [{ "$add": ["label_", "name"] }]
+}
+```
+
+## $timestamp | $id
+
+The `$timestamp` operator is used to retrieve the timestamp of a record as a UNIX time in microseconds.
+The operator is useful when you want to filter records based on their timestamp or when you want to use the timestamp in calculations.
+
+### Syntax
+
+```
+{
+  "$timestamp": []
+}
+```
+
+### Behavior
+
+The operator is a nullary operator that returns the timestamp of the record as a UNIX time in microseconds.
+
+### Examples
+
+Retrieve a certain record by its timestamp:
+
+```json
+{
+  "$timestamp": { "$eq": 1672531199000 }
+}
+```
+
+Retrieve multiple records by their timestamps:
+
+```json
+{
+  "$in": ["$timestamp", 1672531199000, 1672531200000]
 }
 ```

--- a/docs/conditional-query/misc-operators.mdx
+++ b/docs/conditional-query/misc-operators.mdx
@@ -5,15 +5,15 @@ description: Learn how to use miscellaneous operators to filter data in ReductSt
 
 Besides the main categories of operators, ReductStore supports a few miscellaneous operators that provide additional functionality:
 
-| Operator  | Description                                         |
-| --------- | --------------------------------------------------- |
-| `$exists` | Checks if a label exists in a record.               |
-| `$cast`   | Casts a label value to a different type explicitly. |
-| `$ref`    | References a label value in a record explicitly.    |
+| Operator            | Description                                         |
+| ------------------- | --------------------------------------------------- |
+| `$has` \| `$exists` | Checks if a record has specific labels.             |
+| `$cast`             | Casts a label value to a different type explicitly. |
+| `$ref`              | References a label value in a record explicitly.    |
 
-## $exists
+## $has | $exists
 
-The `$exists` operator is used to check if a [**label**](../glossary#label) exists in a [**record**](../glossary#record).
+The `$has` or `$exists` operator is used to check if a [**record**](../glossary#record) has specific [**labels**](../glossary#label).
 
 The operator is useful when you want to filter records based on the presence of a label, regardless of its value.
 
@@ -21,18 +21,19 @@ The operator is useful when you want to filter records based on the presence of 
 
 ```
 {
-  "$exists": [ <expression as label reference> ]
+  "$has" | "$exists" : [ <expression as label reference>, ... ]
 }
 ```
 
 ### Behavior
 
-The operator evaluates the first expression as a string and checks if the label exists in the record.
+The operator evaluates expressions as strings and checks if the record has all the specified labels.
 
 Additional rules:
 
 - If the expression is not a string, it is cast to a string.
 - The operator is case-sensitive.
+- The evaluation stops as soon as one of the labels is not found.
 
 ### Examples
 
@@ -40,7 +41,7 @@ Array notation:
 
 ```json
 {
-  "$exists": ["label_name"]
+  "$has": ["label_1", "label_2"]
 }
 ```
 
@@ -75,8 +76,8 @@ Object notation:
 
 ```json
 {
-  "$cast": {
-    "&label_name": "int"
+  "$label_name": {
+    "$cast": "int"
   }
 }
 ```

--- a/docs/conditional-query/misc-operators.mdx
+++ b/docs/conditional-query/misc-operators.mdx
@@ -38,7 +38,7 @@ Additional rules:
 
 ### Examples
 
-Array notation:
+Check if a record has labels `label_1` and `label_2`:
 
 ```json
 {

--- a/docs/examples/cpp/src/data_querying_filter.cc
+++ b/docs/examples/cpp/src/data_querying_filter.cc
@@ -18,9 +18,9 @@ int main() {
     auto err = bucket->Query("imdb", std::nullopt, std::nullopt, {
             .when=R"({
                 "&photo_taken": {"$gt": 2006},
-                "&name": {"$lt": 4}
+                "&name": {"$lt": 4},
+                "$limit": [10],
             })",
-            .limit = 10,
     }, [](auto rec) {
         std::cout << "Name: " << rec.labels["name"] << std::endl;
         std::cout << "Photo Taken: " << rec.labels["photo_taken"] << std::endl;

--- a/docs/examples/cpp/src/data_querying_filter.cc
+++ b/docs/examples/cpp/src/data_querying_filter.cc
@@ -18,7 +18,7 @@ int main() {
     auto err = bucket->Query("imdb", std::nullopt, std::nullopt, {
             .when=R"({
                 "&photo_taken": {"$gt": 2006},
-                "&name": {"$lt": 4},
+                "&face_score": {"$lt": 4},
                 "$limit": [10]
             })",
     }, [](auto rec) {

--- a/docs/examples/cpp/src/data_querying_filter.cc
+++ b/docs/examples/cpp/src/data_querying_filter.cc
@@ -19,7 +19,7 @@ int main() {
             .when=R"({
                 "&photo_taken": {"$gt": 2006},
                 "&name": {"$lt": 4},
-                "$limit": [10],
+                "$limit": [10]
             })",
     }, [](auto rec) {
         std::cout << "Name: " << rec.labels["name"] << std::endl;

--- a/docs/examples/js/src/data_querying_filter.mjs
+++ b/docs/examples/js/src/data_querying_filter.mjs
@@ -6,10 +6,10 @@ const bucket = await client.getBucket("example-bucket");
 
 // Query 10 photos from "imdb" entry which taken after 2006 with the face score less than 4
 for await (const record of bucket.query("imdb", undefined, undefined, {
-  limit: 10,
   when: {
     "&photo_taken": { $gt: 2006 },
     "&face_score": { $lt: 4 },
+    $limit: [10],
   },
 })) {
   console.log("Name", record.labels.name);

--- a/docs/examples/py/src/data_querying_filter.py
+++ b/docs/examples/py/src/data_querying_filter.py
@@ -11,10 +11,10 @@ async def main():
         # Query 10 photos from "imdb" entry which taken after 2006 with the face score less than 4
         async for record in bucket.query(
                 "imdb",
-                limit=10,
                 when={
                     "&photo_taken": {"$gt": 2006},
                     "&face_score": {"$lt": 4},
+                    "$limit": [10],
                 },
         ):
             print("Name", record.labels["name"])

--- a/docs/examples/rs/examples/data_querying_filter.rs
+++ b/docs/examples/rs/examples/data_querying_filter.rs
@@ -20,9 +20,9 @@ async fn main() -> Result<(), ReductError> {
         .query("imdb")
         .when(condition!({
             "&photo_taken": {"$gt": 2006},
-            "&face_score": {"$gt": 4}
+            "&face_score": {"$gt": 4},
+            "$limit": [10]
         }))
-        .limit(10)
         .send()
         .await?;
 

--- a/docs/examples/rs/examples/data_querying_filter.rs
+++ b/docs/examples/rs/examples/data_querying_filter.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), ReductError> {
         .query("imdb")
         .when(condition!({
             "&photo_taken": {"$gt": 2006},
-            "&face_score": {"$gt": 4},
+            "&face_score": {"$lt": 4},
             "$limit": [10]
         }))
         .send()

--- a/docs/guides/data-querying.mdx
+++ b/docs/guides/data-querying.mdx
@@ -35,34 +35,15 @@ are divided into two categories: filter and control parameters.
 
 Filter parameters are used to select records based on specific criteria. You can combine multiple filter parameters to create complex queries. This is the list of filter parameters, sorted by priority:
 
-| Parameter | Description                     | Type             | Default                                                                 |
-| --------- | ------------------------------- | ---------------- | ----------------------------------------------------------------------- |
-| `start`   | Start time of the query         | Timestamp        | The timestamp of the first record in the **[entry](../glossary#entry)** |
-| `end`     | End time of the query           | Timestamp        | The timestamp of the last record in the entry                           |
-| `when`    | Conditional query               | JSON-like object | No condition                                                            |
-| `each_s`  | Return a record every S seconds | Float            | Disabled                                                                |
-| `each_n`  | Return only every N record      | Integer          | Disabled                                                                |
-| `limit`   | Limit on the number of records  | Integer          | All records are returned                                                |
+| Parameter | Description             | Type             | Default                                                                 |
+| --------- | ----------------------- | ---------------- | ----------------------------------------------------------------------- |
+| `start`   | Start time of the query | Timestamp        | The timestamp of the first record in the **[entry](../glossary#entry)** |
+| `end`     | End time of the query   | Timestamp        | The timestamp of the last record in the entry                           |
+| `when`    | Conditional query       | JSON-like object | No condition                                                            |
 
 **Time Range**
 
 The time range is defined by the `start` and `end` parameters. Records with a timestamp equal to or greater than `start` and less than `end` are included in the result. If the `start` parameter is not set, the query starts from the begging of the entry. If the `end` parameter is not set, the query continues to the end of the entry. If both `start` and `end` are not set, the query returns the entire entry.
-
-**When Condition**
-
-The `when` parameter is used to filter records based on labels. The condition is specified as a JSON-like object. The query returns only records that match the specified condition. The condition can be a simple equality check or a more complex expression using comparison operators. For more information on conditional queries, see the **[Conditional Query Reference](/docs/conditional-query/index.mdx)**.
-
-**One Record Every S Seconds**
-
-The `each_s` parameter returns a record every S seconds. This parameter is useful when you need to resample data at a specific interval. You can use floating-point numbers for better precision. The default value is 0, which means all records are returned.
-
-**Every Nth Record**
-
-The `each_n` parameter returns only every Nth record. This parameter is useful when you need to downsample data by skipping records. The default value is 1, which means all records are returned.
-
-**Limit Records**
-
-The `limit` parameter restricts the number of records returned by a query. If the dataset has fewer records than the specified limit, all records are returned.
 
 ### Control Parameters
 

--- a/docs/http-api/entry-api/run_query.mdx
+++ b/docs/http-api/entry-api/run_query.mdx
@@ -126,12 +126,15 @@ The request body should be a JSON object with the following parameters:
     strict?: "boolean"
 
     // Optional. Return a record every S seconds
+    // DEPRECATED: Use "$each_t" in "when" condition instead.
     each_s?: "float"
 
     // Optional. Return only every N record
+    // DEPRECATED: Use "$each_n" in "when" condition instead.
     each_n?: "integer"
 
     // Optional. The maximum number of records to return.
+    // DEPRECATED: Use "$limit" instead in "when" condition
     limit?: "integer"
 
     // Optional. If true, the query will remain open

--- a/docs/sdk/py/bucket/index.mdx
+++ b/docs/sdk/py/bucket/index.mdx
@@ -208,6 +208,7 @@ float (UNIX timestamp in seconds) or str (ISO 8601 string).
   each_s(Union[int, float]): remove a record for each S seconds
 - `each_n(int)` - remove each N-th record
 - `strict(bool)` - if True: strict query
+- `ext` _dict_ - extended query parameters
 
 **Returns**:
 
@@ -318,16 +319,16 @@ Write a record to entry
 **Raises**:
 
 - `ReductError` - if there is an HTTP error
-  
+
 
 **Example**:
 ```python
       await bucket.write("entry-1", b"some_data",
          timestamp="2021-09-10T10:30:00")
-     
+
       # You can write data chunk-wise using an asynchronous iterator and the
       # size of the content:
-     
+
       async def sender():
           for chunk in [b"part1", b"part2", b"part3"]:
               yield chunk
@@ -380,7 +381,7 @@ If a label is empty, it will be removed.
 **Raises**:
 
 - `ReductError` - if there is an HTTP error
-  
+
 
 **Example**:
 ```python
@@ -414,7 +415,7 @@ If a label is empty, it will be removed.
 **Raises**:
 
 - `ReductError` - if there is an HTTP error
-  
+
 
 **Example**:
 ```python
@@ -465,7 +466,7 @@ float (UNIX timestamp in seconds) or str (ISO 8601 string).
 **Returns**:
 
 - `AsyncIterator[Record]` - iterator to the records
-  
+
 
 **Example**:
 ```python
@@ -527,7 +528,7 @@ float (UNIX timestamp in seconds) or str (ISO 8601 string).
 **Returns**:
 
 - `AsyncIterator[Record]` - iterator to the records
-  
+
 
 **Example**:
 ```python
@@ -537,5 +538,3 @@ float (UNIX timestamp in seconds) or str (ISO 8601 string).
           async for chunk in record.read(n=1024):
               print(chunk)
    ```
-
-

--- a/docs/sdk/py/index.mdx
+++ b/docs/sdk/py/index.mdx
@@ -18,7 +18,7 @@ This package provides an asynchronous HTTP client for interacting with  **[Reduc
 
 ## Features
 
-* Supports the **[ReductStore HTTP API v1.14](https://www.reduct.store/docs/http-api)**
+* Supports the **[ReductStore HTTP API v1.15](https://www.reduct.store/docs/http-api)**
 * Bucket management
 * API Token management
 * Write, read and query data

--- a/docs/sdk/py/msg/bucket/index.mdx
+++ b/docs/sdk/py/msg/bucket/index.mdx
@@ -288,4 +288,8 @@ conditional query to filter records
 
 strict mode for when clause
 
+<a id="reduct.msg.bucket.QueryEntry.ext"></a>
 
+#### ext
+
+additional parameters for extensions

--- a/sidebars.json
+++ b/sidebars.json
@@ -73,9 +73,9 @@
         "conditional-query/logical-operators",
         "conditional-query/comparison-operators",
         "conditional-query/arithmetic-operators",
+        "conditional-query/aggregation-operators",
         "conditional-query/string-operators",
-        "conditional-query/misc-operators",
-        "conditional-query/aggregation-operators"
+        "conditional-query/misc-operators"
       ]
     },
     {

--- a/sidebars.json
+++ b/sidebars.json
@@ -74,7 +74,8 @@
         "conditional-query/comparison-operators",
         "conditional-query/arithmetic-operators",
         "conditional-query/string-operators",
-        "conditional-query/misc-operators"
+        "conditional-query/misc-operators",
+        "conditional-query/aggregation-operators"
       ]
     },
     {


### PR DESCRIPTION
* Document the $has/$exists operator https://github.com/reductstore/reductstore/pull/786
* Document the $each_n operator https://github.com/reductstore/reductstore/pull/788
* Document the $each_t operator https://github.com/reductstore/reductstore/pull/792
* Document the $limit operator https://github.com/reductstore/reductstore/pull/793
* Document the $timestamp operator https://github.com/reductstore/reductstore/pull/798
* Mark the replaced query parameters deprecated 