### PR TITLE
Label update endpoints don't require content-length

### DIFF
--- a/docs/http-api/entry-api/update_data.mdx
+++ b/docs/http-api/entry-api/update_data.mdx
@@ -21,7 +21,7 @@ import SwaggerComponent from "@site/src/components/SwaggerComponent";
 The method allows to update labels of an existing record. It receives
 labels in headers that start with `x-reduct-label-``and updates
 the labels or adds new ones. If a header with a label is empty, the label
-is removed. Because the content of the record is immutable, the method doesn't expect a body, and the content-length header is required, but must be 0.
+is removed. Because the content of the record is immutable, the method doesn't expect a body.
 
 All existing labels not mentioned in the request stay unchanged.
 
@@ -59,14 +59,6 @@ if authentication is enabled.
         name: "ts",
         dataType: "Integer",
         description: "A UNIX timestamp in microseconds",
-        isRequired: true,
-      },
-    },
-    {
-      type: "header",
-      details: {
-        name: "Content-Length",
-        description: "Content-length is required but must be 0",
         isRequired: true,
       },
     },
@@ -116,7 +108,7 @@ if authentication is enabled.
 ## Update Labels of Multiple Records
 
 This method allows to update labels of multiple records in a single request. A client should describe the
-records in headers according to [the Batch Protocol](/docs/http-api/entry-api/index.mdx#batch-protocol). The content-length header is required but must be 0.
+records in headers according to [the Batch Protocol](/docs/http-api/entry-api/index.mdx#batch-protocol).
 
 Existing labels not mentioned in the request stay unchanged.
 


### PR DESCRIPTION
* Update for https://github.com/reductstore/reductstore/pull/800
