### PR TITLE
docs: align query link API docs with strict record identity

### DIFF
--- a/docs/http-api/query-link-api.mdx
+++ b/docs/http-api/query-link-api.mdx
@@ -23,6 +23,8 @@ You can use this method to create a query link for a specific bucket.
 The request body should include the bucket and endpoint, as well as a query parameter to filter the data.
 The given query will be applied to the data when accessed via the link.
 
+`record_entry` and `record_timestamp` are required in the payload. They bind the link preview to an exact record identity instead of positional index.
+
 <SwaggerComponent
   method="post"
   path="/api/v1/links/:file_name"
@@ -81,9 +83,10 @@ The method receives a JSON object in the request body with the following fields:
 {
   expire_at: "integer", // Expiration date in unix timestamp (seconds)
   bucket: "string", // Bucket name
-  entry: "string", // Entry name
+  entry: "string", // Entry name (kept for compatibility)
+  record_entry: "string", // Required record entry name for stable preview resolution
+  record_timestamp: "integer", // Required record timestamp for stable preview resolution
   query: "object", // Query object
-  index: "integer", // (Optional) Record index in the query result to be returned by default (r query parameter)
   base_url: "string", // (Optional) Base URL to use in the generated link
 }
 ```
@@ -92,6 +95,8 @@ The method receives a JSON object in the request body with the following fields:
 
 You can use this method to download data using a query link.
 The method applies the query specified when creating the link to filter the data and returns the content of the record along with metadata in the response headers.
+
+If both `e` and `ts` are passed, they override `record_entry`/`record_timestamp` from the encrypted payload for this request. You must provide both parameters together.
 
 <SwaggerComponent
   method="get"
@@ -133,11 +138,18 @@ The method applies the query specified when creating the link to filter the data
       description: "Name of the token used to create the link",
     },
     {
-      name: "r",
+      name: "e",
       type: "string",
       isRequired: false,
       description:
-        "Record number in the query result to download. If not provided, the first record matching the query will be returned.",
+        "Record entry name override. Must be provided together with ts.",
+    },
+    {
+      name: "ts",
+      type: "string",
+      isRequired: false,
+      description:
+        "Record timestamp override. Must be provided together with e.",
     },
   ]}
   responses={[

--- a/versioned_docs/version-1.19.x/http-api/query-link-api.mdx
+++ b/versioned_docs/version-1.19.x/http-api/query-link-api.mdx
@@ -23,6 +23,8 @@ You can use this method to create a query link for a specific bucket.
 The request body should include the bucket and endpoint, as well as a query parameter to filter the data.
 The given query will be applied to the data when accessed via the link.
 
+`record_entry` and `record_timestamp` are required in the payload. They bind the link preview to an exact record identity instead of positional index.
+
 <SwaggerComponent
   method="post"
   path="/api/v1/links/:file_name"
@@ -81,9 +83,10 @@ The method receives a JSON object in the request body with the following fields:
 {
   expire_at: "integer", // Expiration date in unix timestamp (seconds)
   bucket: "string", // Bucket name
-  entry: "string", // Entry name
+  entry: "string", // Entry name (kept for compatibility)
+  record_entry: "string", // Required record entry name for stable preview resolution
+  record_timestamp: "integer", // Required record timestamp for stable preview resolution
   query: "object", // Query object
-  index: "integer", // (Optional) Record index in the query result to be returned by default (r query parameter)
   base_url: "string", // (Optional) Base URL to use in the generated link
 }
 ```
@@ -92,6 +95,8 @@ The method receives a JSON object in the request body with the following fields:
 
 You can use this method to download data using a query link.
 The method applies the query specified when creating the link to filter the data and returns the content of the record along with metadata in the response headers.
+
+If both `e` and `ts` are passed, they override `record_entry`/`record_timestamp` from the encrypted payload for this request. You must provide both parameters together.
 
 <SwaggerComponent
   method="get"
@@ -133,11 +138,18 @@ The method applies the query specified when creating the link to filter the data
       description: "Name of the token used to create the link",
     },
     {
-      name: "r",
+      name: "e",
       type: "string",
       isRequired: false,
       description:
-        "Record number in the query result to download. If not provided, the first record matching the query will be returned.",
+        "Record entry name override. Must be provided together with ts.",
+    },
+    {
+      name: "ts",
+      type: "string",
+      isRequired: false,
+      description:
+        "Record timestamp override. Must be provided together with e.",
     },
   ]}
   responses={[


### PR DESCRIPTION
Closes #1334

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update

### What was changed?

- Updated Query Link API docs for latest query-link behavior introduced in reductstore/reductstore@3c6ff4d.
- Replaced index-based selection (`index` in payload / `r` in URL) with strict record identity fields:
  - `record_entry`
  - `record_timestamp`
- Documented that `record_entry` + `record_timestamp` are required in create-link payload.
- Updated download endpoint query params to optional override pair `e` + `ts` (must be provided together).
- Applied updates to both current docs and versioned docs (`version-1.19.x`).

### Related issues

- https://github.com/reductstore/reductstore/pull/1334
- https://github.com/reductstore/reductstore/commit/3c6ff4d072ea5317de4ea9c149a2b4f8ac6f5966

### Does this PR introduce a breaking change?

No (documentation-only PR).

### Other information:

This PR keeps docs aligned with server-side validation and query-link parameter handling.
