### PR TITLE
docs: clarify per-connection rate-limit semantics since v1.19.5

### DIFF
--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -27,9 +27,9 @@ jobs:
             image: reduct/pro:latest
             example_root: versioned_docs/version-1.19.x/examples
 
-#          - doc_version: 1.18.x
-#            image: reduct/store:v1.18.10
-#            example_root: versioned_docs/version-1.18.x/examples
+          #          - doc_version: 1.18.x
+          #            image: reduct/store:v1.18.10
+          #            example_root: versioned_docs/version-1.18.x/examples
 
           - example: python
             cmd: python3

--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -16,11 +16,8 @@ jobs:
     strategy:
       matrix:
         example: [python, rust, golang, curl, cpp, node, cli]
-        doc_version: [next, 1.19.x, 1.18.x]
-        # v1.8.x is intentionally excluded from CI for now because reduct-cli `cp`
-        # semantics changed and break the old example bootstrap flow.
-        # Keep this note as a reminder to re-enable once examples are adapted.
-        # doc_version: [next, 1.19.x, 1.18.x, 1.8.x]
+#        doc_version: [next, 1.19.x, 1.18.x]
+        doc_version: [next, 1.19.x] # 2 version because of brake in reduct-cp
         include:
           - doc_version: next
             image: reduct/pro:main

--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         example: [python, rust, golang, curl, cpp, node, cli]
-#        doc_version: [next, 1.19.x, 1.18.x]
+        #        doc_version: [next, 1.19.x, 1.18.x]
         doc_version: [next, 1.19.x] # 2 version because of brake in reduct-cp
         include:
           - doc_version: next

--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -27,9 +27,9 @@ jobs:
             image: reduct/pro:latest
             example_root: versioned_docs/version-1.19.x/examples
 
-          - doc_version: 1.18.x
-            image: reduct/store:v1.18.10
-            example_root: versioned_docs/version-1.18.x/examples
+#          - doc_version: 1.18.x
+#            image: reduct/store:v1.18.10
+#            example_root: versioned_docs/version-1.18.x/examples
 
           - example: python
             cmd: python3

--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -17,6 +17,10 @@ jobs:
       matrix:
         example: [python, rust, golang, curl, cpp, node, cli]
         doc_version: [next, 1.19.x, 1.18.x]
+        # v1.8.x is intentionally excluded from CI for now because reduct-cli `cp`
+        # semantics changed and break the old example bootstrap flow.
+        # Keep this note as a reminder to re-enable once examples are adapted.
+        # doc_version: [next, 1.19.x, 1.18.x, 1.8.x]
         include:
           - doc_version: next
             image: reduct/pro:main

--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -83,13 +83,14 @@ For usage examples, deployment patterns, and a full explanation of key expressio
 
 ## Instance Rate Limiting Settings
 
-ReductStore can enforce instance-level rate limits for both HTTP and Zenoh APIs. Limits are optional and disabled by default.
+ReductStore can enforce rate limits for both HTTP and Zenoh APIs. Limits are optional and disabled by default.
+Since v1.19.5, usage is tracked **per connection** (not globally per instance).
 
 | Name                    | Default | Description                                                                                             |
 | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `RS_RATE_LIMIT_API`     |         | Maximum API request rate. Example: `100req/s`, `100000req/h`, or `1000` (defaults to per hour).         |
-| `RS_RATE_LIMIT_INGRESS` |         | Maximum ingress throughput (writes). Example: `10MB/s`, `10GB/h`, or `500MB` (defaults to per hour).    |
-| `RS_RATE_LIMIT_EGRESS`  |         | Maximum egress throughput (reads/replies). Example: `50MB/s`, `1GB/m`, or `2GB` (defaults to per hour). |
+| `RS_RATE_LIMIT_API`     |         | Maximum API request rate per connection. Example: `100req/s`, `100000req/h`, or `1000` (defaults to per hour).         |
+| `RS_RATE_LIMIT_INGRESS` |         | Maximum ingress throughput (writes) per connection. Example: `10MB/s`, `10GB/h`, or `500MB` (defaults to per hour).    |
+| `RS_RATE_LIMIT_EGRESS`  |         | Maximum egress throughput (reads/replies) per connection. Example: `50MB/s`, `1GB/m`, or `2GB` (defaults to per hour). |
 
 Rate format: `<amount>/<period>`.
 

--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -84,13 +84,14 @@ For usage examples, deployment patterns, and a full explanation of key expressio
 ## Instance Rate Limiting Settings
 
 ReductStore can enforce rate limits for both HTTP and Zenoh APIs. Limits are optional and disabled by default.
-Since v1.19.5, usage is tracked **per connection** (not globally per instance).
+The limits are applied per connection (IP address) for HTTP API and per instance for Zenoh API. The following table describes the available environment variables for rate limiting:
+
 
 | Name                    | Default | Description                                                                                             |
 | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `RS_RATE_LIMIT_API`     |         | Maximum API request rate per connection. Example: `100req/s`, `100000req/h`, or `1000` (defaults to per hour).         |
-| `RS_RATE_LIMIT_INGRESS` |         | Maximum ingress throughput (writes) per connection. Example: `10MB/s`, `10GB/h`, or `500MB` (defaults to per hour).    |
-| `RS_RATE_LIMIT_EGRESS`  |         | Maximum egress throughput (reads/replies) per connection. Example: `50MB/s`, `1GB/m`, or `2GB` (defaults to per hour). |
+| `RS_RATE_LIMIT_API`     |         | Maximum API request rate. Example: `100req/s`, `100000req/h`, or `1000` (defaults to per hour).         |
+| `RS_RATE_LIMIT_INGRESS` |         | Maximum ingress throughput (writes). Example: `10MB/s`, `10GB/h`, or `500MB` (defaults to per hour).    |
+| `RS_RATE_LIMIT_EGRESS`  |         | Maximum egress throughput (reads/replies). Example: `50MB/s`, `1GB/m`, or `2GB` (defaults to per hour). |
 
 Rate format: `<amount>/<period>`.
 

--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -86,7 +86,6 @@ For usage examples, deployment patterns, and a full explanation of key expressio
 ReductStore can enforce rate limits for both HTTP and Zenoh APIs. Limits are optional and disabled by default.
 The limits are applied per connection (IP address) for HTTP API and per instance for Zenoh API. The following table describes the available environment variables for rate limiting:
 
-
 | Name                    | Default | Description                                                                                             |
 | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
 | `RS_RATE_LIMIT_API`     |         | Maximum API request rate. Example: `100req/s`, `100000req/h`, or `1000` (defaults to per hour).         |

--- a/versioned_docs/version-1.19.x/configuration/settings.mdx
+++ b/versioned_docs/version-1.19.x/configuration/settings.mdx
@@ -83,13 +83,14 @@ For usage examples, deployment patterns, and a full explanation of key expressio
 
 ## Instance Rate Limiting Settings
 
-ReductStore can enforce instance-level rate limits for both HTTP and Zenoh APIs. Limits are optional and disabled by default.
+ReductStore can enforce rate limits for both HTTP and Zenoh APIs. Limits are optional and disabled by default.
+Since v1.19.5, usage is tracked **per connection** (not globally per instance).
 
 | Name                    | Default | Description                                                                                             |
 | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `RS_RATE_LIMIT_API`     |         | Maximum API request rate. Example: `100req/s`, `100000req/h`, or `1000` (defaults to per hour).         |
-| `RS_RATE_LIMIT_INGRESS` |         | Maximum ingress throughput (writes). Example: `10MB/s`, `10GB/h`, or `500MB` (defaults to per hour).    |
-| `RS_RATE_LIMIT_EGRESS`  |         | Maximum egress throughput (reads/replies). Example: `50MB/s`, `1GB/m`, or `2GB` (defaults to per hour). |
+| `RS_RATE_LIMIT_API`     |         | Maximum API request rate per connection. Example: `100req/s`, `100000req/h`, or `1000` (defaults to per hour).         |
+| `RS_RATE_LIMIT_INGRESS` |         | Maximum ingress throughput (writes) per connection. Example: `10MB/s`, `10GB/h`, or `500MB` (defaults to per hour).    |
+| `RS_RATE_LIMIT_EGRESS`  |         | Maximum egress throughput (reads/replies) per connection. Example: `50MB/s`, `1GB/m`, or `2GB` (defaults to per hour). |
 
 Rate format: `<amount>/<period>`.
 

--- a/versioned_docs/version-1.19.x/configuration/settings.mdx
+++ b/versioned_docs/version-1.19.x/configuration/settings.mdx
@@ -84,13 +84,14 @@ For usage examples, deployment patterns, and a full explanation of key expressio
 ## Instance Rate Limiting Settings
 
 ReductStore can enforce rate limits for both HTTP and Zenoh APIs. Limits are optional and disabled by default.
-Since v1.19.5, usage is tracked **per connection** (not globally per instance).
+The limits are applied per connection (IP address) for HTTP API and per instance for Zenoh API. The following table describes the available environment variables for rate limiting:
+
 
 | Name                    | Default | Description                                                                                             |
 | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `RS_RATE_LIMIT_API`     |         | Maximum API request rate per connection. Example: `100req/s`, `100000req/h`, or `1000` (defaults to per hour).         |
-| `RS_RATE_LIMIT_INGRESS` |         | Maximum ingress throughput (writes) per connection. Example: `10MB/s`, `10GB/h`, or `500MB` (defaults to per hour).    |
-| `RS_RATE_LIMIT_EGRESS`  |         | Maximum egress throughput (reads/replies) per connection. Example: `50MB/s`, `1GB/m`, or `2GB` (defaults to per hour). |
+| `RS_RATE_LIMIT_API`     |         | Maximum API request rate. Example: `100req/s`, `100000req/h`, or `1000` (defaults to per hour).         |
+| `RS_RATE_LIMIT_INGRESS` |         | Maximum ingress throughput (writes). Example: `10MB/s`, `10GB/h`, or `500MB` (defaults to per hour).    |
+| `RS_RATE_LIMIT_EGRESS`  |         | Maximum egress throughput (reads/replies). Example: `50MB/s`, `1GB/m`, or `2GB` (defaults to per hour). |
 
 Rate format: `<amount>/<period>`.
 

--- a/versioned_docs/version-1.19.x/configuration/settings.mdx
+++ b/versioned_docs/version-1.19.x/configuration/settings.mdx
@@ -86,7 +86,6 @@ For usage examples, deployment patterns, and a full explanation of key expressio
 ReductStore can enforce rate limits for both HTTP and Zenoh APIs. Limits are optional and disabled by default.
 The limits are applied per connection (IP address) for HTTP API and per instance for Zenoh API. The following table describes the available environment variables for rate limiting:
 
-
 | Name                    | Default | Description                                                                                             |
 | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
 | `RS_RATE_LIMIT_API`     |         | Maximum API request rate. Example: `100req/s`, `100000req/h`, or `1000` (defaults to per hour).         |


### PR DESCRIPTION
## Summary
- update current docs to state rate-limit usage is tracked per connection since v1.19.5
- update versioned v1.19.x docs with the same semantics
- clarify RS_RATE_LIMIT_API, RS_RATE_LIMIT_INGRESS, and RS_RATE_LIMIT_EGRESS descriptions accordingly

## Context
ReductStore v1.19.5 changed rate-limit usage accounting from global-per-instance behavior to per-connection behavior.