### PR TITLE
docs: document system event bucket for lifecycle diagnostics

### DIFF
--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -181,3 +181,18 @@ Notes:
 - `RS_AUDIT_ENABLED` explicitly overrides the token-based default.
 - `RS_AUDIT_QUOTA_SIZE` is applied only when audit is enabled.
 - If `RS_AUDIT_QUOTA_SIZE` is unset, `$audit` capacity is unlimited.
+
+## System Event Settings
+
+ReductStore can persist non-API system events in the `$system` bucket. Lifecycle workers use this bucket for `lifecycle_run` diagnostics, while API audit records continue to stay in `$audit`.
+
+| Name                            | Default | Description                                                                                                                        |
+| ------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `RS_SYSTEM_EVENTS_ENABLED`      | true    | Enable or disable persistence of system events in `$system`. When `false`, ReductStore skips writes for lifecycle diagnostics and other system events. |
+| `RS_SYSTEM_EVENTS_QUOTA_SIZE`   |         | Optional size limit for the `$system` bucket (for example `1GB`, `500MB`). When set, `$system` uses FIFO eviction.               |
+
+Notes:
+
+- `lifecycle_run` records are written to `$system` under the `__lifecycle_tasks/<policy-name>` entry path.
+- If `RS_SYSTEM_EVENTS_QUOTA_SIZE` is unset, `$system` capacity is unlimited.
+- On read-only replicas, system events are forwarded through the shared system logging layer instead of being stored locally.

--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -165,31 +165,21 @@ ReductStore supports **[data replication](../guides/data-replication.mdx)** betw
 
 ## Audit Settings
 
-ReductStore can persist aggregated API interactions in the `$audit` system bucket. You can configure audit behavior with the following environment variables:
-
-| Name                         | Default | Description                                                                                                                                                                         |
-| ---------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `RS_AUDIT_ENABLED`           | auto    | Enable or disable audit collection and persistence. If unset, audit defaults to `true` when `RS_API_TOKEN` is set, otherwise `false`. When `false`, ReductStore skips audit writes. |
-| `RS_AUDIT_QUOTA_SIZE`        |         | Optional size limit for the `$audit` bucket (for example `1GB`, `500MB`). When set, `$audit` uses FIFO eviction.                                                                    |
-| `RS_AUDIT_REMOTE_VERIFY_SSL` | true    | For replica audit forwarding over HTTPS: verify TLS certificates of remote nodes.                                                                                                   |
-| `RS_AUDIT_REMOTE_CA_PATH`    |         | For replica audit forwarding: path to a PEM-encoded CA certificate used to verify remote TLS certificates.                                                                          |
-| `RS_AUDIT_REMOTE_TIMEOUT`    | 5       | Timeout in seconds for replica audit HTTP communication with primary/secondary nodes.                                                                                               |
-
-Notes:
-
-- If `RS_AUDIT_ENABLED` is unset, audit defaults to `true` when `RS_API_TOKEN` is set, otherwise `false`.
-- `RS_AUDIT_ENABLED` explicitly overrides the token-based default.
-- `RS_AUDIT_QUOTA_SIZE` is applied only when audit is enabled.
-- If `RS_AUDIT_QUOTA_SIZE` is unset, `$audit` capacity is unlimited.
+:::warning
+Since 1.20 version, $audit bucket is deprecated. The audit events are stored in `$system/audit` entry.
+:::
 
 ## System Event Settings
 
-ReductStore can persist non-API system events in the `$system` bucket. Lifecycle workers use this bucket for `lifecycle_run` diagnostics, while API audit records continue to stay in `$audit`.
+ReductStore can persist audit and system events in the `$system` bucket.
 
-| Name                            | Default | Description                                                                                                                        |
-| ------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `RS_SYSTEM_EVENTS_ENABLED`      | true    | Enable or disable persistence of system events in `$system`. When `false`, ReductStore skips writes for lifecycle diagnostics and other system events. |
-| `RS_SYSTEM_EVENTS_QUOTA_SIZE`   |         | Optional size limit for the `$system` bucket (for example `1GB`, `500MB`). When set, `$system` uses FIFO eviction.               |
+| Name                          | Default | Description                                                                                                        |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `RS_SYSTEM_EVENTS_ENABLED`    | true    | Enable or disable persistence of system events in `$system`.                                                       |
+| `RS_SYSTEM_EVENTS_QUOTA_SIZE` |         | Optional size limit for the `$system` bucket (for example `1GB`, `500MB`). When set, `$system` uses FIFO eviction. |
+| `RS_SYSTEM_EVENTS_VERIFY_SSL` | true    | For replica event forwarding over HTTPS: verify TLS certificates of remote nodes.                                  |
+| `RS_SYSTEM_EVENTS_CA_PATH`    |         | For replica event forwarding: path to a PEM-encoded CA certificate used to verify remote TLS certificates.         |
+| `RS_SYSTEM_EVENTS_TIMEOUT`    | 5       | Timeout in seconds for replica system event HTTP communication with primary/secondary nodes.                       |
 
 Notes:
 

--- a/docs/guides/access-control.mdx
+++ b/docs/guides/access-control.mdx
@@ -64,6 +64,7 @@ The table below shows the list of operations that can be performed for different
 | Manage Tokens            | :x:                | :x:                | :x:                | :x:                | :white_check_mark: |
 | Manage Replication Tasks | :x:                | :x:                | :x:                | :x:                | :white_check_mark: |
 | Access Audit Log         | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Access System Events     | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 :::note
 `Anonymous` refers to clients that don't send an **[access token](../glossary#access-token)** in the `Authorization` header.
@@ -288,6 +289,8 @@ import RemoveTokenCurl from "!!raw-loader!../examples/curl/access_control_remove
 ReductStore provides an audit log that records HTTP API requests, including successful and failed requests.
 The audit log is stored in a separate bucket and can be accessed using the standard API.
 
+API audit events are stored in `$audit`. Non-API system diagnostics, such as lifecycle worker results, are stored separately in `$system`.
+
 The audit bucket `$audit` has the following structure:
 
 ```
@@ -343,4 +346,35 @@ To access the audit log, the relevant token must include exact permissions for t
 
 :::info
 Zenoh API operations are not currently recorded in the audit log (you will not see Zenoh calls in `$audit`).
+:::
+
+## System Events
+
+ReductStore also stores internal system diagnostics in the `$system` bucket.
+This currently includes lifecycle worker results written as `lifecycle_run` records under the `__lifecycle_tasks/<policy-name>` entry path.
+
+A typical lifecycle system event looks like this:
+
+```json
+{
+  "timestamp": 1775270571819933,
+  "instance": "reductstore",
+  "status": 200,
+  "message": "",
+  "policy_name": "purge-old-data",
+  "action_type": "delete",
+  "bucket": "sensor-data",
+  "duration": 0.25,
+  "processed_records": 42
+}
+```
+
+If a lifecycle run fails, the payload also includes `error_code` and `error_message`.
+
+System event persistence is controlled by the `RS_SYSTEM_EVENTS_ENABLED` environment variable. You can optionally limit `$system` growth with `RS_SYSTEM_EVENTS_QUOTA_SIZE`.
+
+On read-only replicas, `$system` events are forwarded through the shared system logging layer instead of being stored locally.
+
+:::info
+To access system events, the relevant token must include exact permissions for the `$system` bucket, either for reading or writing (wildcards do not apply to system buckets).
 :::

--- a/docs/guides/access-control.mdx
+++ b/docs/guides/access-control.mdx
@@ -63,7 +63,6 @@ The table below shows the list of operations that can be performed for different
 | Remove Entry             | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: |
 | Manage Tokens            | :x:                | :x:                | :x:                | :x:                | :white_check_mark: |
 | Manage Replication Tasks | :x:                | :x:                | :x:                | :x:                | :white_check_mark: |
-| Access Audit Log         | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Access System Events     | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 :::note
@@ -287,17 +286,15 @@ import RemoveTokenCurl from "!!raw-loader!../examples/curl/access_control_remove
 ## Audit Log
 
 ReductStore provides an audit log that records HTTP API requests, including successful and failed requests.
-The audit log is stored in a separate bucket and can be accessed using the standard API.
+The audit log is stored in the `$system` bucket and can be accessed using the standard API.
 
-API audit events are stored in `$audit`. Non-API system diagnostics, such as lifecycle worker results, are stored separately in `$system`.
-
-The audit bucket `$audit` has the following structure:
+API audit events are stored in `$syste/audit` entry. The audit entry has the following structure:
 
 ```
-$audit
-|-- <instance-name>
-      |-- <token-name>
-            |-- <UNIX-timestamp>-<JSON record>
+$system/audit/
+    |-- <instance-name>
+          |-- <token-name>
+                |-- <UNIX-timestamp>-<JSON record>
 ```
 
 Audit log records contain aggregated information about API requests, grouped by endpoint and time interval. Each record includes:
@@ -327,9 +324,7 @@ Example:
 }
 ```
 
-Audit logging is controlled by the `RS_AUDIT_ENABLED` environment variable.
-If `RS_AUDIT_ENABLED` is unset, audit defaults to `true` when `RS_API_TOKEN` is set, otherwise `false`.
-Setting `RS_AUDIT_ENABLED` explicitly overrides that default.
+Audit logging is controlled by the `RS_SYSTEM_EVENTS_ENABLED` environment variable and enabled by default.
 
 ### Read-only Replica Behavior
 
@@ -341,40 +336,9 @@ To enable auditing on a read-only replica, configure:
 - `RS_SECONDARY_URL` (optional, for failover)
 
 :::info
-To access the audit log, the relevant token must include exact permissions for the `$audit` bucket, either for reading or writing (wildcards do not apply to system buckets).
+To access the audit log, the relevant token must include exact permissions for the `$system` bucket, either for reading or writing (wildcards do not apply to system buckets).
 :::
 
 :::info
-Zenoh API operations are not currently recorded in the audit log (you will not see Zenoh calls in `$audit`).
-:::
-
-## System Events
-
-ReductStore also stores internal system diagnostics in the `$system` bucket.
-This currently includes lifecycle worker results written as `lifecycle_run` records under the `__lifecycle_tasks/<policy-name>` entry path.
-
-A typical lifecycle system event looks like this:
-
-```json
-{
-  "timestamp": 1775270571819933,
-  "instance": "reductstore",
-  "status": 200,
-  "message": "",
-  "policy_name": "purge-old-data",
-  "action_type": "delete",
-  "bucket": "sensor-data",
-  "duration": 0.25,
-  "processed_records": 42
-}
-```
-
-If a lifecycle run fails, the payload also includes `error_code` and `error_message`.
-
-System event persistence is controlled by the `RS_SYSTEM_EVENTS_ENABLED` environment variable. You can optionally limit `$system` growth with `RS_SYSTEM_EVENTS_QUOTA_SIZE`.
-
-On read-only replicas, `$system` events are forwarded through the shared system logging layer instead of being stored locally.
-
-:::info
-To access system events, the relevant token must include exact permissions for the `$system` bucket, either for reading or writing (wildcards do not apply to system buckets).
+Zenoh API operations are not currently recorded in the audit log (you will not see Zenoh calls in `$system/audit`).
 :::


### PR DESCRIPTION
## Summary
- document the new `$system` bucket in the website docs
- add configuration docs for `RS_SYSTEM_EVENTS_ENABLED` and `RS_SYSTEM_EVENTS_QUOTA_SIZE`
- explain lifecycle `lifecycle_run` records, replica forwarding behavior, and access requirements for system buckets

## Testing
- not run (docs-only changes)

## Related
- reductstore/reductstore#1399
