### PR TITLE
docs: add full backup shortcut to disaster recovery guide

### DIFF
--- a/docs/guides/disaster-recovery.mdx
+++ b/docs/guides/disaster-recovery.mdx
@@ -213,7 +213,13 @@ reduct-cli cp primary/<bucket_name> backup/<bucket_name> \
   --stop <OPTIONAL end timestamp>
 ```
 
-This command supports copying data for a full bucket or within a specific time range, enabling incremental or scheduled backups.
+If you need to back up all buckets from the latest backup data, you can use this more convenient command:
+
+```bash
+reduct-cli cp primary/* backup --from-last
+```
+
+These commands support copying a full bucket or all buckets, as well as limiting the copy to a specific time range for incremental or scheduled backups.
 
 ### Restore Process
 

--- a/versioned_docs/version-1.19.x/guides/disaster-recovery.mdx
+++ b/versioned_docs/version-1.19.x/guides/disaster-recovery.mdx
@@ -213,7 +213,13 @@ reduct-cli cp primary/<bucket_name> backup/<bucket_name> \
   --stop <OPTIONAL end timestamp>
 ```
 
-This command supports copying data for a full bucket or within a specific time range, enabling incremental or scheduled backups.
+If you need to back up all buckets from the latest backup data, you can use this more convenient command:
+
+```bash
+reduct-cli cp primary/* backup --from-last
+```
+
+These commands support copying a full bucket or all buckets, as well as limiting the copy to a specific time range for incremental or scheduled backups.
 
 ### Restore Process
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update

### What was changed?

- added a convenient `reduct-cli cp primary/* backup --from-last` example to the disaster recovery guide
- clarified that the hot-backup CLI workflow can be used to back up all buckets from the latest backup data
- updated the current docs plus the versioned 1.16.x, 1.17.x, 1.18.x, and 1.19.x guides to keep the backup instructions consistent

### Related issues

- none

### Does this PR introduce a breaking change?

No

### Other information:

Docs-only change; tests not run.
