### PR TITLE
docs: fix `when` parameter references in next and v1.19

### DIFF
--- a/docs/guides/data-querying.mdx
+++ b/docs/guides/data-querying.mdx
@@ -75,7 +75,7 @@ The `continuous` flag is used to keep the query open for continuous data retriev
 
 **Strict Mode**
 
-The `strict` flag is used to enable strict mode for conditional queries in the `where` parameter. In strict mode, the query fails if the condition is invalid or contains an unknown field.
+The `strict` flag is used to enable strict mode for conditional queries in the `when` parameter. In strict mode, the query fails if the condition is invalid or contains an unknown field.
 When the strict mode is disabled, the invalid condition is considered as `false` and the unknown field is ignored.
 
 ## Typical Data Querying Cases

--- a/docs/guides/data-replication.mdx
+++ b/docs/guides/data-replication.mdx
@@ -56,7 +56,7 @@ In this case, the conditional replication settings will be:
 
 ```yaml
 entries: ["sensor-1"]
-where: { "&rms": { "$gt": 2.0 }, "&quality": { "$eq": "ok" } }
+when: { "&rms": { "$gt": 2.0 }, "&quality": { "$eq": "ok" } }
 ```
 
 See the next section for more information on how to create a replication task with conditional replication settings.

--- a/versioned_docs/version-1.19.x/guides/data-querying.mdx
+++ b/versioned_docs/version-1.19.x/guides/data-querying.mdx
@@ -75,7 +75,7 @@ The `continuous` flag is used to keep the query open for continuous data retriev
 
 **Strict Mode**
 
-The `strict` flag is used to enable strict mode for conditional queries in the `where` parameter. In strict mode, the query fails if the condition is invalid or contains an unknown field.
+The `strict` flag is used to enable strict mode for conditional queries in the `when` parameter. In strict mode, the query fails if the condition is invalid or contains an unknown field.
 When the strict mode is disabled, the invalid condition is considered as `false` and the unknown field is ignored.
 
 ## Typical Data Querying Cases

--- a/versioned_docs/version-1.19.x/guides/data-replication.mdx
+++ b/versioned_docs/version-1.19.x/guides/data-replication.mdx
@@ -56,7 +56,7 @@ In this case, the conditional replication settings will be:
 
 ```yaml
 entries: ["sensor-1"]
-where: { "&rms": { "$gt": 2.0 }, "&quality": { "$eq": "ok" } }
+when: { "&rms": { "$gt": 2.0 }, "&quality": { "$eq": "ok" } }
 ```
 
 See the next section for more information on how to create a replication task with conditional replication settings.


### PR DESCRIPTION
## Summary
- fix the replication guide example to use `when` instead of `where`
- fix the querying guide text to refer to the `when` parameter in strict mode
- apply the patch only to `next` and `version-1.19.x`

## Testing
- not run (docs-only change)