### PR TITLE
docs(config): document system log events for #1467

### DIFF
--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -171,18 +171,23 @@ Since 1.20 version, $audit bucket is deprecated. The audit events are stored in 
 
 ## System Event Settings
 
-ReductStore can persist audit and system events in the `$system` bucket.
+ReductStore can persist internal events in the `$system` bucket, including audit events, lifecycle diagnostics, replication diagnostics, usage snapshots, and captured instance logs.
 
-| Name                          | Default | Description                                                                                                        |
-| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
-| `RS_SYSTEM_EVENTS_ENABLED`    | true    | Enable or disable persistence of system events in `$system`.                                                       |
-| `RS_SYSTEM_EVENTS_QUOTA_SIZE` |         | Optional size limit for the `$system` bucket (for example `1GB`, `500MB`). When set, `$system` uses FIFO eviction. |
-| `RS_SYSTEM_EVENTS_VERIFY_SSL` | true    | For replica event forwarding over HTTPS: verify TLS certificates of remote nodes.                                  |
-| `RS_SYSTEM_EVENTS_CA_PATH`    |         | For replica event forwarding: path to a PEM-encoded CA certificate used to verify remote TLS certificates.         |
-| `RS_SYSTEM_EVENTS_TIMEOUT`    | 5       | Timeout in seconds for replica system event HTTP communication with primary/secondary nodes.                       |
+| Name                                 | Default | Description                                                                                                         |
+| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `RS_SYSTEM_EVENTS_ENABLED`           | true    | Enable or disable persistence of system events in `$system`.                                                        |
+| `RS_SYSTEM_EVENTS_LOG_LEVEL`         | WARN    | Minimum ReductStore log level persisted to `$system/logs/<instance>/messages`. Set to `OFF` to disable log capture. |
+| `RS_SYSTEM_EVENTS_QUOTA_SIZE`        |         | Optional size limit for the `$system` bucket (for example `1GB`, `500MB`). When set, `$system` uses FIFO eviction. |
+| `RS_SYSTEM_EVENTS_REMOTE_VERIFY_SSL` | true    | For replica event forwarding over HTTPS: verify TLS certificates of remote nodes.                                   |
+| `RS_SYSTEM_EVENTS_REMOTE_CA_PATH`    |         | For replica event forwarding: path to a PEM-encoded CA certificate used to verify remote TLS certificates.          |
+| `RS_SYSTEM_EVENTS_REMOTE_TIMEOUT`    | 5       | Timeout in seconds for replica system event HTTP communication with primary/secondary nodes.                        |
 
 Notes:
 
-- `lifecycle_run` records are written to `$system` under the `__lifecycle_tasks/<policy-name>` entry path.
+- Audit events are written under `$system/audit/<instance>/<token-name>`.
+- Lifecycle diagnostics are written under `$system/lifecycle/<instance>/<policy-name>`.
+- Replication diagnostics are written under `$system/replications/<instance>/<replication-name>`.
+- Usage snapshots are written under `$system/usage/<instance>/total`.
+- Captured ReductStore logs are written under `$system/logs/<instance>/messages`.
 - If `RS_SYSTEM_EVENTS_QUOTA_SIZE` is unset, `$system` capacity is unlimited.
-- On read-only replicas, system events are forwarded through the shared system logging layer instead of being stored locally.
+- On read-only replicas, system events are forwarded through the shared system logging layer instead of being stored locally, but captured logs remain node-local and are not forwarded.


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update

### What was changed?

- documented `RS_SYSTEM_EVENTS_LOG_LEVEL` with the default `WARN` value and `OFF` behavior
- documented the `$system/logs/<instance>/messages` system entry
- updated the `$system` entry path notes for audit, lifecycle, replication, and usage events
- corrected replica forwarding environment variable names to `RS_SYSTEM_EVENTS_REMOTE_VERIFY_SSL`, `RS_SYSTEM_EVENTS_REMOTE_CA_PATH`, and `RS_SYSTEM_EVENTS_REMOTE_TIMEOUT`

### Related issues

- Follow-up for reductstore/reductstore#1467

### Does this PR introduce a breaking change?

No.

### Other information:

- `yarn build` could not be completed in this worktree because the local docs toolchain is unavailable here (`docusaurus: not found`).
- `website` does not have a `CHANGELOG.md`, so there is no changelog update in this repo.
