### PR TITLE
docs: document lifecycle entry patterns

### DIFF
--- a/docs/configuration/provisioning.mdx
+++ b/docs/configuration/provisioning.mdx
@@ -93,7 +93,7 @@ You can provision lifecycle policies by setting environment variables. Lifecycle
 | `RS_LIFECYCLE_<ID>_BUCKET`     |         | Bucket to apply the lifecycle policy to (required)                                                                                                  |
 | `RS_LIFECYCLE_<ID>_OLDER_THAN` |         | Maximum record age before the action is applied, for example `30d`, `24h`, or `3600s` (required). Minimum value is `1h`.                            |
 | `RS_LIFECYCLE_<ID>_INTERVAL`   | 3600s   | Interval between lifecycle runs, for example `10m`, `1h`, or `3600s`. Minimum value is `10m`.                                                       |
-| `RS_LIFECYCLE_<ID>_ENTRIES`    |         | Comma-separated list of entries to clean. If empty, all entries are matched. Prefix wildcards are supported.                                        |
+| `RS_LIFECYCLE_<ID>_ENTRIES`    |         | Comma-separated entry names or patterns to clean. If empty, all entries are matched. Supports `*`, `**`, and `!` exclusions.                        |
 | `RS_LIFECYCLE_<ID>_WHEN`       |         | JSON condition for records to delete. Supported only for `delete` policies. Uses the same condition syntax as queries, but `#ext` is not supported. |
 | `RS_LIFECYCLE_<ID>_MODE`       | enabled | Policy mode: `enabled`, `disabled`, or `dry_run`.                                                                                                   |
 
@@ -103,7 +103,7 @@ Example:
 RS_LIFECYCLE_A_NAME=purge-sensors-30d
 RS_LIFECYCLE_A_TYPE=delete
 RS_LIFECYCLE_A_BUCKET=telemetry
-RS_LIFECYCLE_A_ENTRIES=sensors/*,env/temp,env/humidity
+RS_LIFECYCLE_A_ENTRIES=sensors/**,!sensors/private/**,env/temp,env/humidity
 RS_LIFECYCLE_A_OLDER_THAN=30d
 RS_LIFECYCLE_A_INTERVAL=10m
 RS_LIFECYCLE_A_WHEN={"$eq":["&label","true"]}

--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -177,7 +177,7 @@ ReductStore can persist internal events in the `$system` bucket, including audit
 | ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------- |
 | `RS_SYSTEM_EVENTS_ENABLED`           | true    | Enable or disable persistence of system events in `$system`.                                                        |
 | `RS_SYSTEM_EVENTS_LOG_LEVEL`         | WARN    | Minimum ReductStore log level persisted to `$system/logs/<instance>/messages`. Set to `OFF` to disable log capture. |
-| `RS_SYSTEM_EVENTS_QUOTA_SIZE`        |         | Optional size limit for the `$system` bucket (for example `1GB`, `500MB`). When set, `$system` uses FIFO eviction. |
+| `RS_SYSTEM_EVENTS_QUOTA_SIZE`        |         | Optional size limit for the `$system` bucket (for example `1GB`, `500MB`). When set, `$system` uses FIFO eviction.  |
 | `RS_SYSTEM_EVENTS_REMOTE_VERIFY_SSL` | true    | For replica event forwarding over HTTPS: verify TLS certificates of remote nodes.                                   |
 | `RS_SYSTEM_EVENTS_REMOTE_CA_PATH`    |         | For replica event forwarding: path to a PEM-encoded CA certificate used to verify remote TLS certificates.          |
 | `RS_SYSTEM_EVENTS_REMOTE_TIMEOUT`    | 5       | Timeout in seconds for replica system event HTTP communication with primary/secondary nodes.                        |

--- a/docs/examples/provisioning/lifecycle_create.yml
+++ b/docs/examples/provisioning/lifecycle_create.yml
@@ -14,7 +14,7 @@ services:
       RS_LIFECYCLE_1_TYPE: delete
       RS_LIFECYCLE_1_OLDER_THAN: 30d
       RS_LIFECYCLE_1_INTERVAL: 10m
-      RS_LIFECYCLE_1_ENTRIES: "sensor-1,sensor-2"
+      RS_LIFECYCLE_1_ENTRIES: "sensors/**,!sensors/private/**"
 
       RS_LIFECYCLE_1_WHEN: |
         {

--- a/docs/guides/lifecycle-policies.mdx
+++ b/docs/guides/lifecycle-policies.mdx
@@ -49,7 +49,7 @@ You can configure lifecycle policies using the following settings:
 | ------------ | ----------------------------------------------------------------------------------------------------------- | -------- | --------- |
 | `type`       | Action type (e.g., `delete` or `compress`)                                                                  | Yes      | -         |
 | `bucket`     | Target bucket name                                                                                          | Yes      | -         |
-| `entries`    | List of entries to scope the policy (wildcard `*` supported)                                                | No       | -         |
+| `entries`    | List of entry names or patterns to scope the policy. See [Entry patterns](#entry-patterns).                 | No       | -         |
 | `older_than` | Maximum age of records before action is applied (e.g., `30d`, `1h`, `5m`)                                   | Yes      | -         |
 | `interval`   | Policy execution interval (e.g., `3600s`, `10m`)                                                            | No       | `3600s`   |
 | `when`       | JSON condition to filter records (see **[Conditional Query Reference](/docs/conditional-query/index.mdx)**) | No       | -         |
@@ -59,14 +59,25 @@ You can configure lifecycle policies using the following settings:
 
 You can refine lifecycle policies using the `entries` and `when` parameters:
 
-- **`entries`**: Limit the policy to specific entries (e.g., `sensor-1,sensor-2` or `sensor-*`)
+- **`entries`**: Limit the policy to specific entries or patterns (e.g., `sensor-1,sensor-2` or `sensors/**,!sensors/private/**`)
 - **`when`**: Apply a `delete` policy only to records matching a condition (e.g., `{"&sensor_type": {"$eq": "temperature"}}`). This condition is not supported for `compress` policies.
 
 For more details, see the **[Conditional Query Reference](/docs/conditional-query/index.mdx)**.
 
+### Entry patterns
+
+Lifecycle policies use the same entry pattern semantics as multi-entry queries and replications:
+
+- Exact entry names match unchanged.
+- Include patterns are resolved first, then patterns prefixed with `!` exclude matching entries.
+- If `entries` contains only exclusions, all entries are included first.
+- `*` matches any characters inside one path segment, so `/a/*/b` matches `/a/x/b` but not `/a/x/d/b`.
+- `**` matches recursively across path segments, so `/a/**/b` matches both `/a/x/b` and `/a/x/d/b`.
+- For flat names, a trailing `*` matches names that start with the same prefix, so `cam-*` matches `cam-1` and `cam-left`.
+
 ## Example
 
-Imagine you store telemetry data from temperature sensors in a bucket called `telemetry`. You want to automatically delete records older than 30 days, but only for specific sensors (`sensor-1` and `sensor-2`) and only if the `sensor_type` label equals `temperature`. Here’s how you’d configure the policy:
+Imagine you store telemetry data from temperature sensors in a bucket called `telemetry`. You want to automatically delete records older than 30 days, but only for entries under `sensors/` while excluding private sensor paths, and only if the `sensor_type` label equals `temperature`. Here’s how you’d configure the policy:
 
 <CodeBlock language="yaml">{lifecycleCreate}</CodeBlock>
 

--- a/docs/sdk/js/api/classes/LifecycleSettings.md
+++ b/docs/sdk/js/api/classes/LifecycleSettings.md
@@ -41,7 +41,7 @@ Bucket to apply lifecycle policy.
 
 Defined in: [messages/LifecycleSettings.ts:39](https://github.com/reductstore/reduct-js/blob/main/src/messages/LifecycleSettings.ts#L39)
 
-List of entries to process. If empty, all matching entries are processed.
+List of entry names or patterns to process. If empty, all matching entries are processed. Supports `*`, `**`, and `!` exclusions.
 
 ***
 

--- a/docs/sdk/js/msg/lifecycle-settings/index.mdx
+++ b/docs/sdk/js/msg/lifecycle-settings/index.mdx
@@ -44,7 +44,7 @@ Bucket to apply lifecycle policy.
 
 Defined in: [messages/LifecycleSettings.ts:39](https://github.com/reductstore/reduct-js/blob/main/src/messages/LifecycleSettings.ts#L39)
 
-List of entries to process. If empty, all matching entries are processed.
+List of entry names or patterns to process. If empty, all matching entries are processed. Supports `*`, `**`, and `!` exclusions.
 
 ***
 
@@ -131,4 +131,3 @@ Defined in: [messages/LifecycleSettings.ts:73](https://github.com/reductstore/re
 ##### Returns
 
 `OriginalLifecycleSettings`
-


### PR DESCRIPTION
Closes reductstore/reductstore#1524

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update

### What was changed?

Documented lifecycle task entry pattern support introduced by reductstore/reductstore#1526:

- lifecycle `entries` now mention exact names, `*`, recursive `**`, and `!` exclusions
- lifecycle policy guide now has an entry-pattern semantics section aligned with query and replication filters
- provisioning docs and examples now show recursive includes with exclusions
- JavaScript SDK lifecycle settings docs now describe entry patterns

### Related issues

Related to reductstore/reductstore#1508 and reductstore/reductstore#1526.

### Does this PR introduce a breaking change?

No.

### Other information:

`CHANGELOG.md` is not present in this repository, so there is no changelog file to update here.

Local verification:

```bash
PATH=/tmp/pydoc-markdown-venv/bin:$PATH yarn build
```

The build passed with pre-existing unrelated warnings for CSS minimizer output and the old broken blog anchor on `/blog/robotics-mongodb-vs-reductstore`.
