### PR TITLE
Document replication destination prefix

### DIFF
--- a/docs/guides/data-replication.mdx
+++ b/docs/guides/data-replication.mdx
@@ -44,6 +44,14 @@ A replication task can filter records before replicating them to the target buck
 | `entries` | A list of entry names or patterns that the replication task will use to filter records. If the list is empty, all records are replicated. See [Entry patterns](#entry-patterns).                         | List of strings  |
 | `when`    | A set of conditions that the record must meet to be replicated. The conditions are based on the record labels. For more information, see the **[Conditional Query Reference](/docs/conditional-query)**. | JSON-like object |
 
+### Destination Entry Prefix
+
+Use `dst_prefix` when several source buckets, devices, or robots replicate into the same destination bucket and you want their entries separated by a destination path prefix.
+The prefix is applied only to the destination entry name; it does not filter source entries and does not change the source bucket.
+
+For example, a source entry `camera/front` with `dst_prefix: "robot-1"` is written to the destination as `robot-1/camera/front`.
+If `dst_prefix` is empty or omitted, ReductStore keeps the destination entry name unchanged.
+
 #### Entry patterns
 
 Replication uses the same entry pattern semantics as multi-entry queries:
@@ -94,6 +102,7 @@ To spin up a new replication task, you must provide the following information:
 - **Remote Bucket**: The name of the bucket in the target database to which data will be replicated.
 - **Remote URL**: The URL of the target database.
 - **Remote Token**: The API token of the target database.
+- **Destination Entry Prefix**: An optional `dst_prefix` prepended to destination entry names.
 - **Filter Settings**: See the **[Conditional Replication](#conditional-replication)** section for more information.
 
 If the destination instance uses HTTPS, ReductStore verifies its TLS certificate by default.

--- a/docs/http-api/replication-api.mdx
+++ b/docs/http-api/replication-api.mdx
@@ -83,6 +83,7 @@ diagnostics and settings.
 - v1.8: The endpoint was added
 - v1.14: The `when` field was added with **[conditional query](../glossary#conditional-query)** to filter records
 - v1.18: Added the `mode` field to the replication info and settings
+- Unreleased: Added the `dst_prefix` field to prepend a prefix to destination entry names
 
 <SwaggerComponent
   method="GET"
@@ -130,6 +131,7 @@ diagnostics and settings.
             "dst_bucket": "string",       // name of destination bucket
             "dst_host": "string",         // url of destination host e.g https://play.reduct.store
             "entries": [],                // list of entry names or patterns. If empty, all records will be replicated
+            "dst_prefix": "string",       // prefix prepended to destination entry names. If empty, destination entry names are unchanged
             "include": {
                  "string": "string"       // DEPRECATED. Key-value pairs to include records that should be replicated. If empty, all records will be replicated
             },
@@ -176,6 +178,7 @@ The method creates a replication task with given settings.
 - v1.8: The endpoint was added
 - v1.14: The `when` field was added with conditional query to filter records
 - v1.18: Added optional `mode` to start replications as `enabled`, `paused`, or `disabled`
+- Unreleased: Added optional `dst_prefix` to prepend a prefix to destination entry names
 
 <SwaggerComponent
   method="POST"
@@ -235,6 +238,16 @@ The method creates a replication task with given settings.
         isRequired: false,
         description:
           "List of replication entry names or patterns. If empty, all records will be replicated.",
+      },
+    },
+    {
+      type: "body",
+      details: {
+        name: "dst_prefix",
+        dataType: "String",
+        isRequired: false,
+        description:
+          "Prefix prepended to destination entry names. For example, source entry camera/front with dst_prefix robot-1 is replicated as robot-1/camera/front. If empty or omitted, destination entry names are unchanged.",
       },
     },
     {
@@ -340,6 +353,7 @@ this method, you need an access token with full access.
 - v1.8: The endpoint was added
 - v1.14: The `when` field was added with conditional query to filter records
 - v1.18: Added optional `mode` to switch between `enabled`, `paused`, and `disabled`
+- Unreleased: Added optional `dst_prefix` to prepend a prefix to destination entry names
 
 <SwaggerComponent
   method="PUT"
@@ -399,6 +413,16 @@ this method, you need an access token with full access.
         isRequired: false,
         description:
           "List of replication entry names or patterns. If empty, all records will be replicated.",
+      },
+    },
+    {
+      type: "body",
+      details: {
+        name: "dst_prefix",
+        dataType: "String",
+        isRequired: false,
+        description:
+          "Prefix prepended to destination entry names. For example, source entry camera/front with dst_prefix robot-1 is replicated as robot-1/camera/front. If empty or omitted, destination entry names are unchanged.",
       },
     },
     {

--- a/docs/http-api/replication-api.mdx
+++ b/docs/http-api/replication-api.mdx
@@ -83,7 +83,7 @@ diagnostics and settings.
 - v1.8: The endpoint was added
 - v1.14: The `when` field was added with **[conditional query](../glossary#conditional-query)** to filter records
 - v1.18: Added the `mode` field to the replication info and settings
-- Unreleased: Added the `dst_prefix` field to prepend a prefix to destination entry names
+- v1.21: Added the `dst_prefix` field to prepend a prefix to destination entry names
 
 <SwaggerComponent
   method="GET"
@@ -178,7 +178,7 @@ The method creates a replication task with given settings.
 - v1.8: The endpoint was added
 - v1.14: The `when` field was added with conditional query to filter records
 - v1.18: Added optional `mode` to start replications as `enabled`, `paused`, or `disabled`
-- Unreleased: Added optional `dst_prefix` to prepend a prefix to destination entry names
+- v1.21: Added optional `dst_prefix` to prepend a prefix to destination entry names
 
 <SwaggerComponent
   method="POST"
@@ -353,7 +353,7 @@ this method, you need an access token with full access.
 - v1.8: The endpoint was added
 - v1.14: The `when` field was added with conditional query to filter records
 - v1.18: Added optional `mode` to switch between `enabled`, `paused`, and `disabled`
-- Unreleased: Added optional `dst_prefix` to prepend a prefix to destination entry names
+- v1.21: Added optional `dst_prefix` to prepend a prefix to destination entry names
 
 <SwaggerComponent
   method="PUT"


### PR DESCRIPTION
Closes #357

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update

### What was changed?

- Documented the replication `dst_prefix` field in the HTTP Replication API reference for get/create/update flows.
- Added destination entry prefix behavior to the current Data Replication guide, including destination-only semantics and an example path mapping.

### Related issues

- https://github.com/reductstore/website/issues/357
- https://github.com/reductstore/reductstore/pull/1486

### Does this PR introduce a breaking change?

No.

### Other information:

Validation not run. The website repository instructions ask agents not to run build, typecheck, formatting, or other validation commands.

No CHANGELOG.md update was made; this repository does not use a changelog for docs-only website updates.
