### PR TITLE
docs: document lifecycle processing_interval

### DIFF
--- a/docs/configuration/provisioning.mdx
+++ b/docs/configuration/provisioning.mdx
@@ -87,16 +87,17 @@ These settings apply to all replication tasks created through provisioning, the 
 
 You can provision lifecycle policies by setting environment variables. Lifecycle policies run in the background and currently support deleting or compressing old records in a bucket.
 
-| Name                           | Default | Description                                                                                                                                         |
-| ------------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `RS_LIFECYCLE_<ID>_NAME`       |         | Provisioned lifecycle policy name (required)                                                                                                        |
-| `RS_LIFECYCLE_<ID>_TYPE`       |         | Lifecycle action type (required). Supported values: `delete`, `compress`.                                                                           |
-| `RS_LIFECYCLE_<ID>_BUCKET`     |         | Bucket to apply the lifecycle policy to (required)                                                                                                  |
-| `RS_LIFECYCLE_<ID>_OLDER_THAN` |         | Maximum record age before the action is applied, for example `30d`, `24h`, or `3600s` (required). Minimum value is `1h`.                            |
-| `RS_LIFECYCLE_<ID>_INTERVAL`   | 3600s   | Interval between lifecycle runs, for example `10m`, `1h`, or `3600s`. Minimum value is `10m`.                                                       |
-| `RS_LIFECYCLE_<ID>_ENTRIES`    |         | Comma-separated entry names or patterns to clean. If empty, all entries are matched. Supports `*`, `**`, and `!` exclusions.                        |
-| `RS_LIFECYCLE_<ID>_WHEN`       |         | JSON condition for records to delete. Supported only for `delete` policies. Uses the same condition syntax as queries, but `#ext` is not supported. |
-| `RS_LIFECYCLE_<ID>_MODE`       | enabled | Policy mode: `enabled`, `disabled`, or `dry_run`.                                                                                                   |
+| Name                                    | Default         | Description                                                                                                                                         |
+| --------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RS_LIFECYCLE_<ID>_NAME`                |                 | Provisioned lifecycle policy name (required)                                                                                                        |
+| `RS_LIFECYCLE_<ID>_TYPE`                |                 | Lifecycle action type (required). Supported values: `delete`, `compress`.                                                                           |
+| `RS_LIFECYCLE_<ID>_BUCKET`              |                 | Bucket to apply the lifecycle policy to (required)                                                                                                  |
+| `RS_LIFECYCLE_<ID>_OLDER_THAN`          |                 | Maximum record age before the action is applied, for example `30d`, `24h`, or `3600s` (required). Minimum value is `1h`.                            |
+| `RS_LIFECYCLE_<ID>_INTERVAL`            | 3600s           | Interval between lifecycle runs, for example `10m`, `1h`, or `3600s`. Minimum value is `10m`.                                                       |
+| `RS_LIFECYCLE_<ID>_PROCESSING_INTERVAL` | `24 * interval` | Maximum span of data time processed by one run, for example `6h`, `12h`, or `1d`. Must be a positive duration.                                      |
+| `RS_LIFECYCLE_<ID>_ENTRIES`             |                 | Comma-separated entry names or patterns to clean. If empty, all entries are matched. Supports `*`, `**`, and `!` exclusions.                        |
+| `RS_LIFECYCLE_<ID>_WHEN`                |                 | JSON condition for records to delete. Supported only for `delete` policies. Uses the same condition syntax as queries, but `#ext` is not supported. |
+| `RS_LIFECYCLE_<ID>_MODE`                | enabled         | Policy mode: `enabled`, `disabled`, or `dry_run`.                                                                                                   |
 
 Example:
 
@@ -107,6 +108,7 @@ RS_LIFECYCLE_A_BUCKET=telemetry
 RS_LIFECYCLE_A_ENTRIES=sensors/**,!sensors/private/**,env/temp,env/humidity
 RS_LIFECYCLE_A_OLDER_THAN=30d
 RS_LIFECYCLE_A_INTERVAL=10m
+RS_LIFECYCLE_A_PROCESSING_INTERVAL=6h
 RS_LIFECYCLE_A_WHEN={"$eq":["&label","true"]}
 RS_LIFECYCLE_A_MODE=dry_run
 ```

--- a/docs/examples/curl/lifecycle_policy_create.sh
+++ b/docs/examples/curl/lifecycle_policy_create.sh
@@ -6,5 +6,5 @@ AUTH_HEADER="Authorization: Bearer my-token"
 
 curl -X POST \
   -H "${AUTH_HEADER}" \
-  -d '{"bucket":"my-bucket","entries":["curl-example"],"older_than":"30d","interval":"1h","when":{"&anomaly":{"$eq":1}}}' \
+  -d '{"bucket":"my-bucket","entries":["curl-example"],"older_than":"30d","interval":"1h","processing_interval":"6h","when":{"&anomaly":{"$eq":1}}}' \
   "${API_PATH}"/lifecycles/my-lifecycle

--- a/docs/examples/provisioning/lifecycle_create.yml
+++ b/docs/examples/provisioning/lifecycle_create.yml
@@ -14,6 +14,7 @@ services:
       RS_LIFECYCLE_1_TYPE: delete
       RS_LIFECYCLE_1_OLDER_THAN: 30d
       RS_LIFECYCLE_1_INTERVAL: 10m
+      RS_LIFECYCLE_1_PROCESSING_INTERVAL: 6h
       RS_LIFECYCLE_1_ENTRIES: "sensors/**,!sensors/private/**"
 
       RS_LIFECYCLE_1_WHEN: |

--- a/docs/guides/lifecycle-policies.mdx
+++ b/docs/guides/lifecycle-policies.mdx
@@ -45,15 +45,24 @@ Compression is applied per storage block for efficiency, not per individual reco
 
 You can configure lifecycle policies using the following settings:
 
-| Setting      | Description                                                                                                 | Required | Default   |
-| ------------ | ----------------------------------------------------------------------------------------------------------- | -------- | --------- |
-| `type`       | Action type (e.g., `delete` or `compress`)                                                                  | Yes      | -         |
-| `bucket`     | Target bucket name                                                                                          | Yes      | -         |
-| `entries`    | List of entry names or patterns to scope the policy. See [Entry patterns](#entry-patterns).                 | No       | -         |
-| `older_than` | Maximum age of records before action is applied (e.g., `30d`, `1h`, `5m`)                                   | Yes      | -         |
-| `interval`   | Policy execution interval (e.g., `3600s`, `10m`)                                                            | No       | `3600s`   |
-| `when`       | JSON condition to filter records (see **[Conditional Query Reference](/docs/conditional-query/index.mdx)**) | No       | -         |
-| `mode`       | Policy mode: `enabled` (default), `dry_run`, or `disabled`                                                  | No       | `enabled` |
+| Setting               | Description                                                                                                 | Required | Default         |
+| --------------------- | ----------------------------------------------------------------------------------------------------------- | -------- | --------------- |
+| `type`                | Action type (e.g., `delete` or `compress`)                                                                  | Yes      | -               |
+| `bucket`              | Target bucket name                                                                                          | Yes      | -               |
+| `entries`             | List of entry names or patterns to scope the policy. See [Entry patterns](#entry-patterns).                 | No       | -               |
+| `older_than`          | Maximum age of records before action is applied (e.g., `30d`, `1h`, `5m`)                                   | Yes      | -               |
+| `interval`            | Policy execution interval (e.g., `3600s`, `10m`)                                                            | No       | `3600s`         |
+| `processing_interval` | Maximum span of data time processed by one run (e.g., `6h`, `12h`, `1d`). Must be a positive duration.      | No       | `24 * interval` |
+| `when`                | JSON condition to filter records (see **[Conditional Query Reference](/docs/conditional-query/index.mdx)**) | No       | -               |
+| `mode`                | Policy mode: `enabled` (default), `dry_run`, or `disabled`                                                  | No       | `enabled`       |
+
+## Processing Window
+
+Each lifecycle run processes a bounded span of data time. By default, ReductStore uses a window of `24 * interval` so a policy does not process an unlimited backlog in one run.
+
+Set `processing_interval` to choose that per-run data-time window explicitly. For example, a policy with `interval: "10m"` and `processing_interval: "6h"` runs every 10 minutes but processes at most 6 hours of eligible data time per run. Successive runs continue advancing through the backlog until they reach the current `older_than` cutoff.
+
+When system events are disabled, ReductStore cannot persist lifecycle progress, but `processing_interval` still clamps the full eligible range processed by each run. Records handled by a previous run become ineligible, so later runs continue moving forward.
 
 ## Conditional Policies
 
@@ -91,7 +100,7 @@ For more information on setting up a local ReductStore instance, see the **[Gett
 
 ### Creating a Lifecycle Policy
 
-To create a lifecycle policy, you must provide at least the action type, target bucket, and `older_than`. The examples below also include optional filters (`entries` and `when`) and a custom `interval`.
+To create a lifecycle policy, you must provide at least the action type, target bucket, and `older_than`. The examples below also include optional filters (`entries` and `when`), a custom `interval`, and a `processing_interval`.
 
 import CreateLifecycleCli from "!!raw-loader!../examples/cli/lifecycle_policy_create.sh";
 import CreateLifecyclePy from "!!raw-loader!../examples/py/src/lifecycle_policy_create.py";


### PR DESCRIPTION
## Summary

- Document the lifecycle `processing_interval` setting added in reductstore/reductstore#1549 in the next/current docs only.
- Add the provisioning env var `RS_LIFECYCLE_<ID>_PROCESSING_INTERVAL` to the next provisioning reference.
- Update next lifecycle provisioning and cURL examples to show the new field.

This is for an unreleased server change, so the v1.20 versioned docs are intentionally unchanged.

## Verification

- `yarn fmt:check`
- `PATH="/tmp/website-docs-build-venv/bin:$PATH" yarn build`

Build completed successfully. Docusaurus still reports an unrelated existing broken anchor on `/blog/robotics-mongodb-vs-reductstore`.

Links:
- Server PR: https://github.com/reductstore/reductstore/pull/1549
- Follow-up task: https://github.com/reductstore/reductstore/issues/1577